### PR TITLE
Update to use new client-java futures syntax

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,18 +97,13 @@ java_grpc_compile()
 ################################
 
 load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
-"graknlabs_common", "graknlabs_console", "graknlabs_benchmark")
+"graknlabs_common", "graknlabs_console")
 graknlabs_common()
 graknlabs_console()
-graknlabs_benchmark()
 
 load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl",
 graknlabs_grakn_core_maven_dependencies = "maven_dependencies")
 graknlabs_grakn_core_maven_dependencies()
-
-load("@graknlabs_benchmark//dependencies/maven:dependencies.bzl",
-graknlabs_benchmark_maven_dependencies = "maven_dependencies")
-graknlabs_benchmark_maven_dependencies()
 
 load("@graknlabs_build_tools//bazel:dependencies.bzl", "bazel_rules_docker")
 bazel_rules_docker()
@@ -139,3 +134,7 @@ graknlabs_graql_maven_dependencies()
 
 load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_grabl_tracing")
 graknlabs_grabl_tracing()
+
+load("@graknlabs_grabl_tracing//dependencies/maven:dependencies.bzl",
+graknlabs_grabl_tracing_maven_dependencies = "maven_dependencies")
+graknlabs_grabl_tracing_maven_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,18 +97,18 @@ java_grpc_compile()
 ################################
 
 load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
-"graknlabs_common", "graknlabs_console", "graknlabs_benchmark")
+"graknlabs_common", "graknlabs_console", "graknlabs_verification")
 graknlabs_common()
 graknlabs_console()
-graknlabs_benchmark()
+graknlabs_verification()
 
 load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl",
 graknlabs_grakn_core_maven_dependencies = "maven_dependencies")
 graknlabs_grakn_core_maven_dependencies()
 
-load("@graknlabs_benchmark//dependencies/maven:dependencies.bzl",
-graknlabs_benchmark_maven_dependencies = "maven_dependencies")
-graknlabs_benchmark_maven_dependencies()
+load("@graknlabs_verification//dependencies/maven:dependencies.bzl",
+graknlabs_verification_maven_dependencies = "maven_dependencies")
+graknlabs_verification_maven_dependencies()
 
 load("@graknlabs_build_tools//bazel:dependencies.bzl", "bazel_rules_docker")
 bazel_rules_docker()

--- a/agents/AgeUpdateAgent.java
+++ b/agents/AgeUpdateAgent.java
@@ -53,7 +53,7 @@ public class AgeUpdateAgent extends CityAgent {
     private Stream<ConceptMap> getPeopleBornInCity() {
         GraqlGet.Sorted peopleQuery = getPeopleBornInCityQuery();
         log().query("getPeopleBornInCity", peopleQuery);
-        return tx().stream(peopleQuery);
+        return tx().stream(peopleQuery).get();
     }
 
     private GraqlGet.Sorted getPeopleBornInCityQuery() {

--- a/agents/FriendshipAgent.java
+++ b/agents/FriendshipAgent.java
@@ -44,7 +44,7 @@ public class FriendshipAgent extends CityAgent {
                         .rel("friendship_friend", Graql.var("p1"))
                         .rel("friendship_friend", Graql.var("p2"))).get().count();
         log().query("checkIfFriendshipExists", friendshipExistsQuery);
-        List<Numeric> answer = tx().execute(friendshipExistsQuery);
+        List<Numeric> answer = tx().execute(friendshipExistsQuery).get();
         int numAnswers = answer.get(0).number().intValue();
         return numAnswers > 0;
     }

--- a/agents/ParentshipAgent.java
+++ b/agents/ParentshipAgent.java
@@ -72,7 +72,7 @@ public class ParentshipAgent extends CityAgent {
         ).get().sort("marriage-id");
 
         log().query("getMarriageEmails", marriageQuery);
-        List<ConceptMap> marriageAnswers = tx().execute(marriageQuery);
+        List<ConceptMap> marriageAnswers = tx().execute(marriageQuery).get();
 
         return marriageAnswers
                 .stream()

--- a/agents/test/QueryCountE2E.java
+++ b/agents/test/QueryCountE2E.java
@@ -30,7 +30,7 @@ public class QueryCountE2E {
     private void assertQueryCount(GraqlGet.Aggregate countQuery, int expectedCount) {
         try (GraknClient.Session session = graknClient.session(KEYSPACE)) {
             try (GraknClient.Transaction tx = session.transaction().write()) {
-                List<Numeric> answer = tx.execute(countQuery);
+                List<Numeric> answer = tx.execute(countQuery).get();
                 int numAnswers = answer.get(0).number().intValue();
                 assertThat(numAnswers, equalTo(expectedCount));
             }

--- a/common/ExecutorUtils.java
+++ b/common/ExecutorUtils.java
@@ -13,8 +13,7 @@ public class ExecutorUtils {
 
     @SuppressWarnings("unchecked")
     public static <T> List<T> getOrderedAttribute(GraknClient.Transaction tx, GraqlGet query, String attributeName, Integer limit){
-        return tx.execute(query)
-                .stream()
+        return tx.stream(query).get()
                 .map(conceptMap -> (T) conceptMap.get(attributeName).asAttribute().value())
                 .sorted()
                 .limit(limit)
@@ -23,8 +22,7 @@ public class ExecutorUtils {
 
     @SuppressWarnings("unchecked")
     public static <T> List<T> getOrderedAttribute(GraknClient.Transaction tx, GraqlGet query, String attributeName){
-        return tx.execute(query)
-                .stream()
+        return tx.stream(query).get()
                 .map(conceptMap -> (T) conceptMap.get(attributeName).asAttribute().value())
                 .sorted()
                 .collect(Collectors.toList());

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,14 +29,14 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "5d249d01f8f2612ffad6927bf1f43852d06c2fd0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "311f58f3052de05f01638a4f6ad375b274ef80c2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        commit = "66564a2c0113accfd70847ae444a8e3714b71620" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        commit = "e753c7c1997a1e041441a1f93f9a1ab0bd467848" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,19 +29,19 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "5d249d01f8f2612ffad6927bf1f43852d06c2fd0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        tag = "1.7.1" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        commit = "66564a2c0113accfd70847ae444a8e3714b71620" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        tag = "1.7.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():
     git_repository(
         name = "graknlabs_grabl_tracing",
         remote = "https://github.com/graknlabs/grabl-tracing",
-        commit = "42f507d6b973cbc87d18a27ee83121c791295184" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
+        tag = "0.1.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -36,12 +36,12 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        tag = "1.7.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        tag = "1.7.3" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():
     git_repository(
         name = "graknlabs_grabl_tracing",
         remote = "https://github.com/graknlabs/grabl-tracing",
-        tag = "0.1.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
+        commit = "dffb8a5ba7ef3749a7f50c6afdcfef8ffca304d7" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
     )

--- a/schema/schema.gql
+++ b/schema/schema.gql
@@ -57,7 +57,7 @@ content-language sub attribute,
 num-characters sub attribute,
     datatype long;
 
-text-content sub attribute, 
+text-content sub attribute,
     datatype string,
     has content-language,
     has num-characters;


### PR DESCRIPTION
## What is the goal of this PR?

For 1.8, `client-java` syntax has changed to return a `Future` from query methods. This requires us to update on our end.

## What are the changes implemented in this PR?

- Updated to new `client-java` syntax