### PR TITLE
Parameterise the number of instances inserted by each agent

### DIFF
--- a/Simulation.java
+++ b/Simulation.java
@@ -44,7 +44,8 @@ import static grabl.tracing.client.GrablTracing.withLogging;
 public class Simulation implements AgentContext, AutoCloseable {
 
     private final static long RANDOM_SEED = 1;
-    private final static int NUM_ITERATIONS = 10;
+    private final static int DEFAULT_NUM_ITERATIONS = 10;
+    private final static int DEFAULT_SCALE_FACTOR = 5;
     private final static Logger LOG = LoggerFactory.getLogger(Simulation.class);
 
     private static Optional<String> getOption(CommandLine commandLine, String option) {
@@ -89,11 +90,15 @@ public class Simulation implements AgentContext, AutoCloseable {
         options.addOption(Option.builder("i")
                 .longOpt("iterations").desc("Number of simulation iterations").hasArg().argName("iterations")
                 .build());
+        options.addOption(Option.builder("f")
+                .longOpt("scale-factor").desc("Scale factor of iteration data").hasArg().argName("scale-factor")
+                .build());
         options.addOption(Option.builder("k")
                 .longOpt("keyspace").desc("Grakn keyspace").hasArg().required().argName("keyspace")
                 .build());
         options.addOption(Option.builder("d")
-                .longOpt("disable-tracing").desc("Disable grabl tracing").build());
+                .longOpt("disable-tracing").desc("Disable grabl tracing")
+                .build());
 
         CommandLineParser parser = new DefaultParser();
         CommandLine commandLine;
@@ -120,7 +125,8 @@ public class Simulation implements AgentContext, AutoCloseable {
 
         boolean disableTracing = commandLine.hasOption("d");
 
-        int iterations = getOption(commandLine, "i").map(Integer::parseInt).orElse(NUM_ITERATIONS);
+        int iterations = getOption(commandLine, "i").map(Integer::parseInt).orElse(DEFAULT_NUM_ITERATIONS);
+        int scaleFactor = getOption(commandLine, "f").map(Integer::parseInt).orElse(DEFAULT_SCALE_FACTOR);
         String graknKeyspace = commandLine.getOptionValue("k");
 
         Map<String, Path> files = new HashMap<>();
@@ -139,6 +145,7 @@ public class Simulation implements AgentContext, AutoCloseable {
         World world;
         try {
             world = new World(
+                    scaleFactor,
                     files.get("continents.csv"),
                     files.get("countries.csv"),
                     files.get("cities.csv"),

--- a/agents/CompanyAgent.java
+++ b/agents/CompanyAgent.java
@@ -8,11 +8,12 @@ import org.apache.commons.lang3.StringUtils;
 
 public class CompanyAgent extends CountryAgent {
 
-    private static final int NUM_COMPANIES = 5;
-
     @Override
     public void iterate() {
-        for (int i = 0; i < NUM_COMPANIES; i++) {
+
+        int numCompanies = world().getScaleFactor();
+
+        for (int i = 0; i < numCompanies; i++) {
             insertCompany(i);
         }
         tx().commit();

--- a/agents/EmploymentAgent.java
+++ b/agents/EmploymentAgent.java
@@ -14,8 +14,6 @@ import static grakn.simulation.common.Allocation.allocate;
 
 public class EmploymentAgent extends CityAgent {
 
-    private static final int NUM_EMPLOYMENTS = 5;
-    private static final int NUM_COMPANIES = 5;
     private static final double MIN_ANNUAL_WAGE = 18000.00;
     private static final double MAX_ANNUAL_WAGE = 80000.00;
     private static final double MIN_CONTRACTED_HOURS = 30.0;
@@ -43,13 +41,15 @@ public class EmploymentAgent extends CityAgent {
     private List<Long> getCompanyNumbers() {
         GraqlGet companyNumbersQuery = CompanyAgent.getCompanyNumbersInCountryQuery(city().country());
         log().query("getEmployeeEmails", companyNumbersQuery);
-        return ExecutorUtils.getOrderedAttribute(tx(), companyNumbersQuery, "company-number", NUM_COMPANIES);
+        int numCompanies = world().getScaleFactor();
+        return ExecutorUtils.getOrderedAttribute(tx(), companyNumbersQuery, "company-number", numCompanies);
     }
 
     private List<String> getEmployeeEmails(LocalDateTime earliestDate) {
         GraqlGet.Unfiltered getEmployeeEmailsQuery = cityResidentsQuery(city(), earliestDate);
         log().query("getEmployeeEmails", getEmployeeEmailsQuery);
-        return ExecutorUtils.getOrderedAttribute(tx(), getEmployeeEmailsQuery, "email", NUM_EMPLOYMENTS);
+        int numEmployments = world().getScaleFactor();
+        return ExecutorUtils.getOrderedAttribute(tx(), getEmployeeEmailsQuery, "email", numEmployments);
     }
 
     private void insertEmployment(String employeeEmail, Long companyNumber){

--- a/agents/FriendshipAgent.java
+++ b/agents/FriendshipAgent.java
@@ -14,8 +14,6 @@ import static grakn.simulation.agents.RelocationAgent.cityResidentsQuery;
 
 public class FriendshipAgent extends CityAgent {
 
-    private static int NUM_FRIENDSHIPS = 5;
-
     @Override
     public void iterate() {
 
@@ -23,7 +21,8 @@ public class FriendshipAgent extends CityAgent {
         closeTx();  // TODO Closing and reopening the transaction here is a workaround for https://github.com/graknlabs/grakn/issues/5585
         if (residentEmails.size() > 0) {
             shuffle(residentEmails);
-            for (int i = 0; i < NUM_FRIENDSHIPS; i++) {
+            int numFriendships = world().getScaleFactor();
+            for (int i = 0; i < numFriendships; i++) {
 
                 String friend1 = pickOne(residentEmails);
                 String friend2 = pickOne(residentEmails);

--- a/agents/MarriageAgent.java
+++ b/agents/MarriageAgent.java
@@ -13,8 +13,6 @@ import static grakn.simulation.common.ExecutorUtils.getOrderedAttribute;
 
 public class MarriageAgent extends CityAgent {
 
-    private static final int NUM_MARRIAGES = 5;
-
     @Override
     public void iterate() {
         // Find bachelors and bachelorettes who are considered adults and who are not in a marriage and pair them off randomly
@@ -24,7 +22,9 @@ public class MarriageAgent extends CityAgent {
         List<String> menEmails = getSingleMen();
         shuffle(menEmails);
 
-        int numMarriagesPossible = Math.min(NUM_MARRIAGES, Math.min(womenEmails.size(), menEmails.size()));
+        int numMarriages = world().getScaleFactor();
+
+        int numMarriagesPossible = Math.min(numMarriages, Math.min(womenEmails.size(), menEmails.size()));
 
         if (numMarriagesPossible > 0) {
 

--- a/agents/PersonBirthAgent.java
+++ b/agents/PersonBirthAgent.java
@@ -6,12 +6,11 @@ import graql.lang.query.GraqlInsert;
 
 public class PersonBirthAgent extends CityAgent {
 
-    private static final int NUM_BIRTHS = 5;
-
     @Override
     public void iterate() {
         // Find bachelors and bachelorettes who are considered adults and who are not in a marriage and pair them off randomly
-        for (int i = 0; i < NUM_BIRTHS; i++) {
+        int numBirths = world().getScaleFactor();
+        for (int i = 0; i < numBirths; i++) {
             insertPerson(i);
         }
         tx().commit();

--- a/agents/ProductAgent.java
+++ b/agents/ProductAgent.java
@@ -7,11 +7,10 @@ import graql.lang.query.GraqlInsert;
 
 public class ProductAgent extends ContinentAgent {
 
-    private static int NUM_PRODUCTS = 5;
-
     @Override
     public void iterate() {
-        for (int i = 0; i < NUM_PRODUCTS; i++) {
+        int numProducts = world().getScaleFactor();
+        for (int i = 0; i < numProducts; i++) {
             insertProduct(i);
         }
         tx().commit();

--- a/agents/RelocationAgent.java
+++ b/agents/RelocationAgent.java
@@ -16,8 +16,6 @@ import static grakn.simulation.common.ExecutorUtils.getOrderedAttribute;
 
 public class RelocationAgent extends CityAgent {
 
-    private static final int NUM_RELOCATIONS = 5;
-
     @Override
     public void iterate() {
         /*
@@ -62,7 +60,8 @@ public class RelocationAgent extends CityAgent {
     private List<String> getResidentEmails(LocalDateTime earliestDate) {
         GraqlGet.Unfiltered cityResidentsQuery = cityResidentsQuery(city(), earliestDate);
         log().query("getResidentEmails", cityResidentsQuery);
-        return ExecutorUtils.getOrderedAttribute(tx(), cityResidentsQuery, "email", NUM_RELOCATIONS);
+        int numRelocations = world().getScaleFactor();
+        return ExecutorUtils.getOrderedAttribute(tx(), cityResidentsQuery, "email", numRelocations);
     }
 
     private List<String> getRelocationCityNames() {

--- a/agents/TransactionAgent.java
+++ b/agents/TransactionAgent.java
@@ -16,7 +16,7 @@ import static grakn.simulation.common.ExecutorUtils.getOrderedAttribute;
 
 public class TransactionAgent extends CountryAgent {
 
-    private int NUM_TRANSACTIONS_PER_COMPANY_ON_AVERAGE = 5;
+    private int NUM_TRANSACTIONS_PER_COMPANY_ON_AVERAGE = 1;
 
     @Override
     public void iterate() {
@@ -24,7 +24,7 @@ public class TransactionAgent extends CountryAgent {
         List<Double> productBarcodes = getProductBarcodesInContinent();
         shuffle(companyNumbers);
 
-        int numTransactions = NUM_TRANSACTIONS_PER_COMPANY_ON_AVERAGE * companyNumbers.size();
+        int numTransactions = NUM_TRANSACTIONS_PER_COMPANY_ON_AVERAGE * world().getScaleFactor() * companyNumbers.size();
 
         // Company numbers is the list of sellers
         // Company numbers picked randomly is the list of buyers

--- a/agents/World.java
+++ b/agents/World.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 public class World {
 
     static final int AGE_OF_ADULTHOOD = 2;
+    private final int scaleFactor;
     private Path logDirPath;
 
     private List<Continent> continents = new ArrayList<>();
@@ -33,7 +34,10 @@ public class World {
     private final List<String> adjectives;
     private final List<String> nouns;
 
-    public World(Path continentsPath, Path countriesPath, Path citiesPath, Path femaleForenamesPath, Path maleForenamesPath, Path surnamesPath, Path adjectivesPath, Path nounsPath) throws IOException {
+    public World(int scaleFactor, Path continentsPath, Path countriesPath, Path citiesPath, Path femaleForenamesPath, Path maleForenamesPath, Path surnamesPath, Path adjectivesPath, Path nounsPath) throws IOException {
+
+        this.scaleFactor = scaleFactor;
+
         try {
             this.logDirPath = Paths.get(System.getenv("LOG_DIR_PATH"));
         } catch (NullPointerException n){
@@ -99,6 +103,10 @@ public class World {
 
     public List<String> getNouns() {
         return nouns;
+    }
+
+    public int getScaleFactor() {
+        return scaleFactor;
     }
 
     public class Continent {


### PR DESCRIPTION
## What is the goal of this PR?

We add functionality such that the quantity of data inserted in each iteration of the simulation is customisable by a user-defined parameter.

## What are the changes implemented in this PR?

- Agents which insert a fixed number of concepts now accesses the globally available `scaleFactor`, and use this as a multiplier for the number of instances they should insert.
