### PR TITLE
Upgrade grabl tracing verison

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -43,5 +43,5 @@ def graknlabs_grabl_tracing():
     git_repository(
         name = "graknlabs_grabl_tracing",
         remote = "https://github.com/graknlabs/grabl-tracing",
-        commit = "ef402d500034ad2d5c9106c95d15804f29f1334c"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
+        commit = "38dc7e195c67a669b69b0bfedc8a7c6032201c2f"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
     )


### PR DESCRIPTION
## What is the goal of this PR?

We recently updated `grabl-tracing` to fix an issue of not being able to perform grakn tracing. Update the `grabl-tracing` version so that we can use the latest grakn for grakn tracing.
