### PR TITLE
Refactor WORKSPACE and declare CI targets using a filegroup

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -53,3 +53,13 @@ java_binary(
     main_class = "grakn.simulation.Simulation",
     runtime_deps = [":simulation-lib"],
 )
+
+# CI targets that are not declared in any BUILD file, but are called externally
+filegroup(
+    name = "ci",
+    data = [
+        "@graknlabs_dependencies//tool/bazelrun:rbe",
+        "@graknlabs_dependencies//distribution/artifact:create-netrc",
+        "@graknlabs_dependencies//tool/unuseddeps:unused-deps",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,20 +21,38 @@ workspace(name = "graknlabs_simulation")
 ################################
 # Load @graknlabs_dependencies #
 ################################
+
 load("//dependencies/graknlabs:repositories.bzl", "graknlabs_dependencies")
 graknlabs_dependencies()
 
-# Load Antlr
+# Load //builder/bazel for RBE
+load("@graknlabs_dependencies//builder/bazel:deps.bzl", "bazel_toolchain")
+bazel_toolchain()
+
+# Load //builder/java
+load("@graknlabs_dependencies//builder/java:deps.bzl", java_deps = "deps")
+java_deps()
+
+# Load //builder/kotlin
+load("@graknlabs_dependencies//builder/kotlin:deps.bzl", kotlin_deps = "deps")
+kotlin_deps()
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+kotlin_repositories()
+kt_register_toolchains()
+
+# Load //builder/python
+load("@graknlabs_dependencies//builder/python:deps.bzl", python_deps = "deps")
+python_deps()
+load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
+pip_repositories()
+
+# Load //builder/antlr
 load("@graknlabs_dependencies//builder/antlr:deps.bzl", antlr_deps = "deps")
 antlr_deps()
 load("@rules_antlr//antlr:deps.bzl", "antlr_dependencies")
 antlr_dependencies()
 
-# Load Bazel
-load("@graknlabs_dependencies//builder/bazel:deps.bzl", "bazel_toolchain")
-bazel_toolchain()
-
-# Load gRPC
+# Load //builder/grpc
 load("@graknlabs_dependencies//builder/grpc:deps.bzl", grpc_deps = "deps")
 grpc_deps()
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl",
@@ -42,129 +60,67 @@ com_github_grpc_grpc_deps = "grpc_deps")
 com_github_grpc_grpc_deps()
 load("@stackb_rules_proto//java:deps.bzl", "java_grpc_compile")
 java_grpc_compile()
-load("@stackb_rules_proto//node:deps.bzl", "node_grpc_compile")
-node_grpc_compile()
 
-# Load Java
-load("@graknlabs_dependencies//builder/java:deps.bzl", java_deps = "deps")
-java_deps()
-load("@graknlabs_dependencies//library/maven:rules.bzl", "maven")
+# Load //tool/common
+load("@graknlabs_dependencies//tool/common:deps.bzl", "graknlabs_dependencies_ci_pip",
+    graknlabs_dependencies_tool_maven_artifacts = "maven_artifacts")
+graknlabs_dependencies_ci_pip()
+load("@graknlabs_dependencies_ci_pip//:requirements.bzl", "pip_install")
+pip_install()
 
-# Load Kotlin
-load("@graknlabs_dependencies//builder/kotlin:deps.bzl", kotlin_deps = "deps")
-kotlin_deps()
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
-kotlin_repositories()
-kt_register_toolchains()
-
-# Load NodeJS
-load("@graknlabs_dependencies//builder/nodejs:deps.bzl", nodejs_deps = "deps")
-nodejs_deps()
-load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
-node_repositories()
-
-# Load Python
-load("@graknlabs_dependencies//builder/python:deps.bzl", python_deps = "deps")
-python_deps()
-load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
-pip_repositories()
-pip3_import(
-    name = "graknlabs_dependencies_ci_pip",
-    requirements = "@graknlabs_dependencies//tool:requirements.txt",
-)
-load("@graknlabs_dependencies_ci_pip//:requirements.bzl",
-graknlabs_dependencies_ci_pip_install = "pip_install")
-graknlabs_dependencies_ci_pip_install()
-
-# Load Docker
-load("@graknlabs_dependencies//distribution/docker:deps.bzl", docker_deps = "deps")
-docker_deps()
-
-# Load Checkstyle
+# Load //tool/checkstyle
 load("@graknlabs_dependencies//tool/checkstyle:deps.bzl", checkstyle_deps = "deps")
 checkstyle_deps()
 
-# Load Sonarcloud
-load("@graknlabs_dependencies//tool/sonarcloud:deps.bzl", "sonarcloud_dependencies")
-sonarcloud_dependencies()
-
-# Load Unused Deps
+# Load //tool/unuseddeps
 load("@graknlabs_dependencies//tool/unuseddeps:deps.bzl", unuseddeps_deps = "deps")
 unuseddeps_deps()
 
-#####################################################################
-# Load @graknlabs_bazel_distribution (from @graknlabs_dependencies) #
-#####################################################################
-load("@graknlabs_dependencies//dependencies/graknlabs:repositories.bzl", "graknlabs_bazel_distribution")
+# Load //tool/sonarcloud
+load("@graknlabs_dependencies//tool/sonarcloud:deps.bzl", "sonarcloud_dependencies")
+sonarcloud_dependencies()
+
+######################################
+# Load @graknlabs_bazel_distribution #
+######################################
+
+load("@graknlabs_dependencies//distribution:deps.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 
-pip3_import(
-    name = "graknlabs_bazel_distribution_pip",
-    requirements = "@graknlabs_bazel_distribution//pip:requirements.txt",
-)
-load("@graknlabs_bazel_distribution_pip//:requirements.bzl",
-graknlabs_bazel_distribution_pip_install = "pip_install")
-graknlabs_bazel_distribution_pip_install()
-
-load("@graknlabs_bazel_distribution//github:dependencies.bzl", "tcnksm_ghr")
-tcnksm_ghr()
-
-load("@graknlabs_bazel_distribution//common:dependencies.bzl", "bazelbuild_rules_pkg")
-bazelbuild_rules_pkg()
-
+# Load //common
+load("@graknlabs_bazel_distribution//common:deps.bzl", "rules_pkg")
+rules_pkg()
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
-#################################
-# Load @graknlabs_grabl_tracing #
-#################################
-load("//dependencies/graknlabs:repositories.bzl", "graknlabs_grabl_tracing")
+# Load //github
+load("@graknlabs_bazel_distribution//github:deps.bzl", github_deps = "deps")
+github_deps()
+
+################################
+# Load @graknlabs dependencies #
+################################
+
+# Load repositories
+load("//dependencies/graknlabs:repositories.bzl", "graknlabs_grabl_tracing", "graknlabs_client_java")
 graknlabs_grabl_tracing()
-
-###############################
-# Load @graknlabs_client_java #
-###############################
-load("//dependencies/graknlabs:repositories.bzl", "graknlabs_client_java")
 graknlabs_client_java()
-load("@graknlabs_client_java//dependencies/maven:artifacts.bzl", graknlabs_client_java_artifacts = "artifacts")
-
-########################################################
-# Load @graknlabs_common (from @graknlabs_client_java) #
-#######################################################
-load("@graknlabs_client_java//dependencies/graknlabs:repositories.bzl", "graknlabs_common")
+load("@graknlabs_client_java//dependencies/graknlabs:repositories.bzl", "graknlabs_common", "graknlabs_graql", "graknlabs_protocol")
 graknlabs_common()
-
-#######################################################
-# Load @graknlabs_graql (from @graknlabs_client_java) #
-#######################################################
-load("@graknlabs_client_java//dependencies/graknlabs:repositories.bzl", "graknlabs_graql")
 graknlabs_graql()
-load("@graknlabs_graql//dependencies/maven:artifacts.bzl", graknlabs_graql_artifacts = "artifacts")
-
-##########################################################
-# Load @graknlabs_protocol (from @graknlabs_client_java) #
-##########################################################
-load("@graknlabs_client_java//dependencies/graknlabs:repositories.bzl", "graknlabs_protocol")
 graknlabs_protocol()
-load("@graknlabs_protocol//dependencies/maven:artifacts.bzl", graknlabs_protocol_artifacts = "artifacts")
 
-#######################################
-# Load @graknlabs_grakn_core_artifact #
-#######################################
+# Load artifact
 load("//dependencies/graknlabs:artifacts.bzl", "graknlabs_grakn_core_artifact")
 graknlabs_grakn_core_artifact()
 
-###############
-# Load @maven #
-###############
-load("//dependencies/maven:artifacts.bzl", "artifacts")
-maven(
-    artifacts +
-    graknlabs_graql_artifacts +
-    graknlabs_protocol_artifacts +
-    graknlabs_client_java_artifacts
-)
+# Load maven
+load("//dependencies/maven:artifacts.bzl", graknlabs_simulation_artifacts = "artifacts")
+load("@graknlabs_client_java//dependencies/maven:artifacts.bzl", graknlabs_client_java_artifacts = "artifacts")
+load("@graknlabs_graql//dependencies/maven:artifacts.bzl", graknlabs_graql_artifacts = "artifacts")
+load("@graknlabs_protocol//dependencies/maven:artifacts.bzl", graknlabs_protocol_artifacts = "artifacts")
 
+# Load neo4j
 load("@rules_jvm_external//:defs.bzl", rje_maven_install = "maven_install")
 rje_maven_install(
     name = "neo4j",
@@ -175,3 +131,16 @@ rje_maven_install(
     strict_visibility = True,
     version_conflict_policy = "pinned"
 )
+
+###############
+# Load @maven #
+###############
+
+load("@graknlabs_dependencies//library/maven:rules.bzl", "maven")
+maven(
+    graknlabs_simulation_artifacts +
+    graknlabs_graql_artifacts +
+    graknlabs_protocol_artifacts +
+    graknlabs_client_java_artifacts
+)
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -132,9 +132,9 @@ rje_maven_install(
     version_conflict_policy = "pinned"
 )
 
-###############
-# Load @maven #
-###############
+############################
+# Load @maven dependencies #
+############################
 
 load("@graknlabs_dependencies//library/maven:rules.bzl", "maven")
 maven(

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -22,14 +22,14 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "a83649f0d777440c86ffbf4ecb4bb33fd0312bf3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "1c86421327bec68a83c3f88d728add07010f797a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/alexjpwalker/client-java", # TODO: revert to graknlabs
-        commit = "918be3a15467f1414a5a94c4e2b667e6fe8b0d4d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        commit = "5406beb1765ce03cedc5716eb48a3098a49898dd",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -29,7 +29,7 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/alexjpwalker/client-java", # TODO: revert to graknlabs
-        commit = "5406beb1765ce03cedc5716eb48a3098a49898dd",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        commit = "c57ca6d142c01a2414cb87721e02baf59d000609",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():


### PR DESCRIPTION
## What is the goal of this PR?
We have refactor the WORKSPACE file to make it clearer. The key change was to properly enclose declarations into appropriate sections. We also add a new toplevel BUILD file declaration for all targets used in CI and elsewhere to ensure these targets are correct at build time.