### PR TITLE
Update usage of native_artifact_files

### DIFF
--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -24,8 +24,8 @@ def graknlabs_grakn_core_artifacts():
     native_artifact_files(
         name = "graknlabs_grakn_core_artifact",
         group_name = "graknlabs_grakn_core",
-        artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
+        artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "d511985f5add21e6bc537010d12cdbdd9c661f4f",
+        commit = "81653e39fa681d20b37fdba13f158a0d1c1a6c2e",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -22,7 +22,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "3ae6737bca677534c998d296598ef207c3a7059e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "b6ddf3ee17d91df9bbed294392d0adba5737da44",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_client_java():


### PR DESCRIPTION
## What is the goal of this PR?

We need to update the usage of `native_artifact_files` to account for different artifact file extensions (`.tar.gz` vs `.zip`)

## What are the changes implemented in this PR?

* Use templated extension in `native_artifact_files`
* Bump `@graknlabs_dependencies`
* Bump `@graknlabs_grakn_core_artifact`