### PR TITLE
Add Grakn Cluster benchmark

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -46,7 +46,6 @@ build:
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
 
-        sleep 1800
         bazel run --config=rbe //:benchmark-small -- \
           --database "Grakn Cluster 2.0" \
           --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI \

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -63,7 +63,7 @@ build:
       type: background
       timeout: "5h"
       command: |
-        cat > grakn.service <<- EOM
+        cat > grakn-core.service <<- EOM
         [Unit]
         Description=Grakn Core
 
@@ -78,13 +78,13 @@ build:
         WantedBy=multi-user.target
         EOM
 
-        sudo mv grakn.service /etc/systemd/system/
+        sudo mv grakn-core.service /etc/systemd/system/
 
-        bazel run --config=rbe //test:grakn-extractor-linux -- dist/grakn-core-all-linux
+        bazel run --config=rbe //test:grakn-core-extractor-linux -- dist/grakn-core-all-linux
         cd ./dist/grakn-core-all-linux/
 
         sudo systemctl daemon-reload
-        sudo systemctl start grakn
+        sudo systemctl start grakn-core
         export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CORE_URI="${HOSTNAME}:1729"
       monitor: |
         sleep 10s

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -35,7 +35,8 @@ build:
         export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI="${HOSTNAME}:1729"
       monitor: |
         sleep 10s
-        tail -f -n +1 /home/grabl/$GRABL_REPO/dist/grakn-cluster-all-linux/server/logs/grakn.log
+        pwd
+        tail -f -n +1 /home/grabl/simulation/dist/grakn-cluster-all-linux/server/logs/grakn.log
     test-performance-small-grakn-cluster:
       image: graknlabs-ubuntu-20.04
       timeout: "5h"

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -35,8 +35,7 @@ build:
         export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI="${HOSTNAME}:1729"
       monitor: |
         sleep 10s
-        pwd
-        tail -f -n +1 /home/grabl/simulation/dist/grakn-cluster-all-linux/server/logs/grakn.log
+        tail -f -n +1 ./simulation/dist/grakn-cluster-all-linux/server/logs/grakn.log
     test-performance-small-grakn-cluster:
       image: graknlabs-ubuntu-20.04
       timeout: "5h"

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -36,7 +36,7 @@ build:
         sudo systemctl start grakn-cluster
       monitor: |
         sleep 10s
-        tail -f -n +1 ./simulation/dist/grakn-cluster-all-linux/server/logs/grakn.log
+        tail -f -n +1 ./benchmark/dist/grakn-cluster-all-linux/server/logs/grakn.log
     test-performance-small-grakn-cluster:
       image: graknlabs-ubuntu-20.04
       timeout: "5h"
@@ -57,85 +57,85 @@ build:
           --username $GRABL_OWNER \
           --api-token $GRABL_TOKEN \
           --config-file /home/grabl/$GRABL_REPO/config/config_test.yml
-#    test-performance-small-grakn-core-background:
-#      machine: 16cpus-32gb
-#      image: graknlabs-ubuntu-20.04
-#      type: background
-#      timeout: "5h"
-#      command: |
-#        cat > grakn.service <<- EOM
-#        [Unit]
-#        Description=Grakn Core
-#
-#        [Service]
-#        Type=simple
-#        ExecStart=/home/grabl/benchmark/dist/grakn-core-all-linux/grakn server
-#        Restart=on-failure
-#        RestartSec=10
-#        KillMode=process
-#
-#        [Install]
-#        WantedBy=multi-user.target
-#        EOM
-#
-#        sudo mv grakn.service /etc/systemd/system/
-#
-#        bazel run --config=rbe //test:grakn-extractor-linux -- dist/grakn-core-all-linux
-#        cd ./dist/grakn-core-all-linux/
-#
-#        sudo systemctl daemon-reload
-#        sudo systemctl start grakn
-#        export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CORE_URI="${HOSTNAME}:1729"
-#      monitor: |
-#        sleep 10s
-#        tail -f -n +1 /home/grabl/benchmark/dist/grakn-core-all-linux/server/logs/grakn.log
-#    test-performance-small-grakn-core:
-#      image: graknlabs-ubuntu-20.04
-#      timeout: "5h"
-#      dependencies: [test-performance-small-grakn-core-background]
-#      command: |
-#        bazel run --config=rbe //:benchmark-small -- \
-#          --database "Grakn Core 2.0" \
-#          --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CORE_URI \
-#          --tracing-uri $GRABL_TRACING_URI \
-#          --org $GRABL_OWNER \
-#          --repo $GRABL_REPO \
-#          --commit $GRABL_COMMIT \
-#          --username $GRABL_OWNER \
-#          --api-token $GRABL_TOKEN \
-#          --config-file /home/grabl/$GRABL_REPO/config/config_test.yml
-#    test-performance-small-neo4j-background:
-#      machine: 16cpus-32gb
-#      image: graknlabs-ubuntu-20.04
-#      type: background
-#      timeout: "5h"
-#      command: |
-#        sudo add-apt-repository -y ppa:openjdk-r/ppa
-#        curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
-#        curl https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-#        sudo apt-get update
-#        wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
-#        echo 'deb https://debian.neo4j.com stable 4.1' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
-#        sudo apt-get update
-#        sudo apt-get install -y neo4j=1:4.1.0
-#        sudo update-java-alternatives --jre --set java-1.11.0-openjdk-amd64
-#        echo 'dbms.connectors.default_listen_address=0.0.0.0' | sudo tee -a /etc/neo4j/neo4j.conf
-#        echo 'dbms.security.auth_enabled=false' | sudo tee -a /etc/neo4j/neo4j.conf
-#        ps aux | grep "org.neo4j.server" | awk '{print $2}' | xargs sudo kill -9 >/dev/null 2&>1 || true
-#        sudo neo4j start
-#        export GRABL_EXPORT_PERFORMANCE_SMALL_NEO4J_URI="bolt://${HOSTNAME}:7687"
-#    test-performance-small-neo4j:
-#      image: graknlabs-ubuntu-20.04
-#      dependencies: [test-performance-small-neo4j-background]
-#      timeout: "5h"
-#      command: |
-#        bazel run --config=rbe //:benchmark-small -- \
-#          --database Neo4j \
-#          --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_NEO4J_URI \
-#          --tracing-uri $GRABL_TRACING_URI \
-#          --org $GRABL_OWNER \
-#          --repo $GRABL_REPO \
-#          --commit $GRABL_COMMIT \
-#          --username $GRABL_OWNER \
-#          --api-token $GRABL_TOKEN \
-#          --config-file /home/grabl/$GRABL_REPO/config/config_test.yml
+    test-performance-small-grakn-core-background:
+      machine: 16cpus-32gb
+      image: graknlabs-ubuntu-20.04
+      type: background
+      timeout: "5h"
+      command: |
+        cat > grakn.service <<- EOM
+        [Unit]
+        Description=Grakn Core
+
+        [Service]
+        Type=simple
+        ExecStart=/home/grabl/benchmark/dist/grakn-core-all-linux/grakn server
+        Restart=on-failure
+        RestartSec=10
+        KillMode=process
+
+        [Install]
+        WantedBy=multi-user.target
+        EOM
+
+        sudo mv grakn.service /etc/systemd/system/
+
+        bazel run --config=rbe //test:grakn-extractor-linux -- dist/grakn-core-all-linux
+        cd ./dist/grakn-core-all-linux/
+
+        sudo systemctl daemon-reload
+        sudo systemctl start grakn
+        export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CORE_URI="${HOSTNAME}:1729"
+      monitor: |
+        sleep 10s
+        tail -f -n +1 /home/grabl/benchmark/dist/grakn-core-all-linux/server/logs/grakn.log
+    test-performance-small-grakn-core:
+      image: graknlabs-ubuntu-20.04
+      timeout: "5h"
+      dependencies: [test-performance-small-grakn-core-background]
+      command: |
+        bazel run --config=rbe //:benchmark-small -- \
+          --database "Grakn Core 2.0" \
+          --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CORE_URI \
+          --tracing-uri $GRABL_TRACING_URI \
+          --org $GRABL_OWNER \
+          --repo $GRABL_REPO \
+          --commit $GRABL_COMMIT \
+          --username $GRABL_OWNER \
+          --api-token $GRABL_TOKEN \
+          --config-file /home/grabl/$GRABL_REPO/config/config_test.yml
+    test-performance-small-neo4j-background:
+      machine: 16cpus-32gb
+      image: graknlabs-ubuntu-20.04
+      type: background
+      timeout: "5h"
+      command: |
+        sudo add-apt-repository -y ppa:openjdk-r/ppa
+        curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
+        curl https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+        sudo apt-get update
+        wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
+        echo 'deb https://debian.neo4j.com stable 4.1' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
+        sudo apt-get update
+        sudo apt-get install -y neo4j=1:4.1.0
+        sudo update-java-alternatives --jre --set java-1.11.0-openjdk-amd64
+        echo 'dbms.connectors.default_listen_address=0.0.0.0' | sudo tee -a /etc/neo4j/neo4j.conf
+        echo 'dbms.security.auth_enabled=false' | sudo tee -a /etc/neo4j/neo4j.conf
+        ps aux | grep "org.neo4j.server" | awk '{print $2}' | xargs sudo kill -9 >/dev/null 2&>1 || true
+        sudo neo4j start
+        export GRABL_EXPORT_PERFORMANCE_SMALL_NEO4J_URI="bolt://${HOSTNAME}:7687"
+    test-performance-small-neo4j:
+      image: graknlabs-ubuntu-20.04
+      dependencies: [test-performance-small-neo4j-background]
+      timeout: "5h"
+      command: |
+        bazel run --config=rbe //:benchmark-small -- \
+          --database Neo4j \
+          --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_NEO4J_URI \
+          --tracing-uri $GRABL_TRACING_URI \
+          --org $GRABL_OWNER \
+          --repo $GRABL_REPO \
+          --commit $GRABL_COMMIT \
+          --username $GRABL_OWNER \
+          --api-token $GRABL_TOKEN \
+          --config-file /home/grabl/$GRABL_REPO/config/config_test.yml

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -1,6 +1,53 @@
 build:
   performance:
-    test-performance-small-grakn-background:
+    test-performance-small-grakn-cluster-background:
+      machine: 16cpus-32gb
+      image: graknlabs-ubuntu-20.04
+      type: background
+      timeout: "5h"
+      command: |
+        cat > grakn-cluster.service <<- EOM
+        [Unit]
+        Description=Grakn Cluster
+
+        [Service]
+        Type=simple
+        ExecStart=/home/grabl/benchmark/dist/grakn-cluster-all-linux/grakn server
+        Restart=on-failure
+        RestartSec=10
+        KillMode=process
+
+        [Install]
+        WantedBy=multi-user.target
+        EOM
+
+        sudo mv grakn-cluster.service /etc/systemd/system/
+
+        bazel run --config=rbe //test:grakn-cluster-extractor-linux -- dist/grakn-cluster-all-linux
+        cd ./dist/grakn-cluster-all-linux/
+
+        sudo systemctl daemon-reload
+        sudo systemctl start grakn-cluster
+        export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI="${HOSTNAME}:1729"
+      monitor: |
+        sleep 10s
+        tail -f -n +1 /home/grabl/benchmark/dist/grakn-cluster-all-linux/server/logs/grakn.log
+    test-performance-small-grakn-cluster:
+      image: graknlabs-ubuntu-20.04
+      timeout: "5h"
+      dependencies: [test-performance-small-grakn-cluster-background]
+      command: |
+        bazel run --config=rbe //:benchmark-small -- \
+          --database "Grakn Cluster 2.0" \
+          --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI \
+          --tracing-uri $GRABL_TRACING_URI \
+          --org $GRABL_OWNER \
+          --repo $GRABL_REPO \
+          --commit $GRABL_COMMIT \
+          --username $GRABL_OWNER \
+          --api-token $GRABL_TOKEN \
+          --config-file /home/grabl/$GRABL_REPO/config/config_test.yml
+    test-performance-small-grakn-core-background:
       machine: 16cpus-32gb
       image: graknlabs-ubuntu-20.04
       type: background
@@ -28,18 +75,18 @@ build:
 
         sudo systemctl daemon-reload
         sudo systemctl start grakn
-        export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_URI="${HOSTNAME}:1729"
+        export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CORE_URI="${HOSTNAME}:1729"
       monitor: |
         sleep 10s
         tail -f -n +1 /home/grabl/benchmark/dist/grakn-core-all-linux/server/logs/grakn.log
-    test-performance-small-grakn:
+    test-performance-small-grakn-core:
       image: graknlabs-ubuntu-20.04
       timeout: "5h"
-      dependencies: [test-performance-small-grakn-background]
+      dependencies: [test-performance-small-grakn-core-background]
       command: |
         bazel run --config=rbe //:benchmark-small -- \
           --database "Grakn Core 2.0" \
-          --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_URI \
+          --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CORE_URI \
           --tracing-uri $GRABL_TRACING_URI \
           --org $GRABL_OWNER \
           --repo $GRABL_REPO \

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -16,7 +16,7 @@ build:
 
         [Service]
         Type=simple
-        ExecStart=/home/grabl/benchmark/dist/grakn-cluster-all-linux/grakn server
+        ExecStart=/home/grabl/$GRABL_REPO/dist/grakn-cluster-all-linux/grakn server
         Restart=on-failure
         RestartSec=10
         KillMode=process
@@ -35,7 +35,7 @@ build:
         export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI="${HOSTNAME}:1729"
       monitor: |
         sleep 10s
-        tail -f -n +1 /home/grabl/benchmark/dist/grakn-cluster-all-linux/server/logs/grakn.log
+        tail -f -n +1 /home/grabl/$GRABL_REPO/dist/grakn-cluster-all-linux/server/logs/grakn.log
     test-performance-small-grakn-cluster:
       image: graknlabs-ubuntu-20.04
       timeout: "5h"
@@ -44,7 +44,7 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        
+
         bazel run --config=rbe //:benchmark-small -- \
           --database "Grakn Cluster 2.0" \
           --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI \

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -18,7 +18,7 @@ build:
 
         [Service]
         Type=simple
-        ExecStart=/home/grabl/$GRABL_REPO/dist/grakn-cluster-all-linux/grakn server --address=$GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI
+        ExecStart=/home/grabl/$GRABL_REPO/dist/grakn-cluster-all-linux/grakn server --address=$GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI:1730
         Restart=on-failure
         RestartSec=10
         KillMode=process

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -45,6 +45,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
 
+        sleep 1800
         bazel run --config=rbe //:benchmark-small -- \
           --database "Grakn Cluster 2.0" \
           --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI \

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -47,85 +47,85 @@ build:
           --username $GRABL_OWNER \
           --api-token $GRABL_TOKEN \
           --config-file /home/grabl/$GRABL_REPO/config/config_test.yml
-    test-performance-small-grakn-core-background:
-      machine: 16cpus-32gb
-      image: graknlabs-ubuntu-20.04
-      type: background
-      timeout: "5h"
-      command: |
-        cat > grakn.service <<- EOM
-        [Unit]
-        Description=Grakn Core
-
-        [Service]
-        Type=simple
-        ExecStart=/home/grabl/benchmark/dist/grakn-core-all-linux/grakn server
-        Restart=on-failure
-        RestartSec=10
-        KillMode=process
-
-        [Install]
-        WantedBy=multi-user.target
-        EOM
-
-        sudo mv grakn.service /etc/systemd/system/
-
-        bazel run --config=rbe //test:grakn-extractor-linux -- dist/grakn-core-all-linux
-        cd ./dist/grakn-core-all-linux/
-
-        sudo systemctl daemon-reload
-        sudo systemctl start grakn
-        export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CORE_URI="${HOSTNAME}:1729"
-      monitor: |
-        sleep 10s
-        tail -f -n +1 /home/grabl/benchmark/dist/grakn-core-all-linux/server/logs/grakn.log
-    test-performance-small-grakn-core:
-      image: graknlabs-ubuntu-20.04
-      timeout: "5h"
-      dependencies: [test-performance-small-grakn-core-background]
-      command: |
-        bazel run --config=rbe //:benchmark-small -- \
-          --database "Grakn Core 2.0" \
-          --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CORE_URI \
-          --tracing-uri $GRABL_TRACING_URI \
-          --org $GRABL_OWNER \
-          --repo $GRABL_REPO \
-          --commit $GRABL_COMMIT \
-          --username $GRABL_OWNER \
-          --api-token $GRABL_TOKEN \
-          --config-file /home/grabl/$GRABL_REPO/config/config_test.yml
-    test-performance-small-neo4j-background:
-      machine: 16cpus-32gb
-      image: graknlabs-ubuntu-20.04
-      type: background
-      timeout: "5h"
-      command: |
-        sudo add-apt-repository -y ppa:openjdk-r/ppa
-        curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
-        curl https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-        sudo apt-get update
-        wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
-        echo 'deb https://debian.neo4j.com stable 4.1' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
-        sudo apt-get update
-        sudo apt-get install -y neo4j=1:4.1.0
-        sudo update-java-alternatives --jre --set java-1.11.0-openjdk-amd64
-        echo 'dbms.connectors.default_listen_address=0.0.0.0' | sudo tee -a /etc/neo4j/neo4j.conf
-        echo 'dbms.security.auth_enabled=false' | sudo tee -a /etc/neo4j/neo4j.conf
-        ps aux | grep "org.neo4j.server" | awk '{print $2}' | xargs sudo kill -9 >/dev/null 2&>1 || true
-        sudo neo4j start
-        export GRABL_EXPORT_PERFORMANCE_SMALL_NEO4J_URI="bolt://${HOSTNAME}:7687"
-    test-performance-small-neo4j:
-      image: graknlabs-ubuntu-20.04
-      dependencies: [test-performance-small-neo4j-background]
-      timeout: "5h"
-      command: |
-        bazel run --config=rbe //:benchmark-small -- \
-          --database Neo4j \
-          --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_NEO4J_URI \
-          --tracing-uri $GRABL_TRACING_URI \
-          --org $GRABL_OWNER \
-          --repo $GRABL_REPO \
-          --commit $GRABL_COMMIT \
-          --username $GRABL_OWNER \
-          --api-token $GRABL_TOKEN \
-          --config-file /home/grabl/$GRABL_REPO/config/config_test.yml
+#    test-performance-small-grakn-core-background:
+#      machine: 16cpus-32gb
+#      image: graknlabs-ubuntu-20.04
+#      type: background
+#      timeout: "5h"
+#      command: |
+#        cat > grakn.service <<- EOM
+#        [Unit]
+#        Description=Grakn Core
+#
+#        [Service]
+#        Type=simple
+#        ExecStart=/home/grabl/benchmark/dist/grakn-core-all-linux/grakn server
+#        Restart=on-failure
+#        RestartSec=10
+#        KillMode=process
+#
+#        [Install]
+#        WantedBy=multi-user.target
+#        EOM
+#
+#        sudo mv grakn.service /etc/systemd/system/
+#
+#        bazel run --config=rbe //test:grakn-extractor-linux -- dist/grakn-core-all-linux
+#        cd ./dist/grakn-core-all-linux/
+#
+#        sudo systemctl daemon-reload
+#        sudo systemctl start grakn
+#        export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CORE_URI="${HOSTNAME}:1729"
+#      monitor: |
+#        sleep 10s
+#        tail -f -n +1 /home/grabl/benchmark/dist/grakn-core-all-linux/server/logs/grakn.log
+#    test-performance-small-grakn-core:
+#      image: graknlabs-ubuntu-20.04
+#      timeout: "5h"
+#      dependencies: [test-performance-small-grakn-core-background]
+#      command: |
+#        bazel run --config=rbe //:benchmark-small -- \
+#          --database "Grakn Core 2.0" \
+#          --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CORE_URI \
+#          --tracing-uri $GRABL_TRACING_URI \
+#          --org $GRABL_OWNER \
+#          --repo $GRABL_REPO \
+#          --commit $GRABL_COMMIT \
+#          --username $GRABL_OWNER \
+#          --api-token $GRABL_TOKEN \
+#          --config-file /home/grabl/$GRABL_REPO/config/config_test.yml
+#    test-performance-small-neo4j-background:
+#      machine: 16cpus-32gb
+#      image: graknlabs-ubuntu-20.04
+#      type: background
+#      timeout: "5h"
+#      command: |
+#        sudo add-apt-repository -y ppa:openjdk-r/ppa
+#        curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
+#        curl https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+#        sudo apt-get update
+#        wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
+#        echo 'deb https://debian.neo4j.com stable 4.1' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
+#        sudo apt-get update
+#        sudo apt-get install -y neo4j=1:4.1.0
+#        sudo update-java-alternatives --jre --set java-1.11.0-openjdk-amd64
+#        echo 'dbms.connectors.default_listen_address=0.0.0.0' | sudo tee -a /etc/neo4j/neo4j.conf
+#        echo 'dbms.security.auth_enabled=false' | sudo tee -a /etc/neo4j/neo4j.conf
+#        ps aux | grep "org.neo4j.server" | awk '{print $2}' | xargs sudo kill -9 >/dev/null 2&>1 || true
+#        sudo neo4j start
+#        export GRABL_EXPORT_PERFORMANCE_SMALL_NEO4J_URI="bolt://${HOSTNAME}:7687"
+#    test-performance-small-neo4j:
+#      image: graknlabs-ubuntu-20.04
+#      dependencies: [test-performance-small-neo4j-background]
+#      timeout: "5h"
+#      command: |
+#        bazel run --config=rbe //:benchmark-small -- \
+#          --database Neo4j \
+#          --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_NEO4J_URI \
+#          --tracing-uri $GRABL_TRACING_URI \
+#          --org $GRABL_OWNER \
+#          --repo $GRABL_REPO \
+#          --commit $GRABL_COMMIT \
+#          --username $GRABL_OWNER \
+#          --api-token $GRABL_TOKEN \
+#          --config-file /home/grabl/$GRABL_REPO/config/config_test.yml

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -6,6 +6,8 @@ build:
       type: background
       timeout: "5h"
       command: |
+        export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI="${HOSTNAME}:1729"
+
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
@@ -16,7 +18,7 @@ build:
 
         [Service]
         Type=simple
-        ExecStart=/home/grabl/$GRABL_REPO/dist/grakn-cluster-all-linux/grakn server
+        ExecStart=/home/grabl/$GRABL_REPO/dist/grakn-cluster-all-linux/grakn server --address=$GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI
         Restart=on-failure
         RestartSec=10
         KillMode=process
@@ -32,7 +34,6 @@ build:
 
         sudo systemctl daemon-reload
         sudo systemctl start grakn-cluster
-        export GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI="${HOSTNAME}:1729"
       monitor: |
         sleep 10s
         tail -f -n +1 ./simulation/dist/grakn-cluster-all-linux/server/logs/grakn.log

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -6,6 +6,10 @@ build:
       type: background
       timeout: "5h"
       command: |
+        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
+
         cat > grakn-cluster.service <<- EOM
         [Unit]
         Description=Grakn Cluster
@@ -37,6 +41,10 @@ build:
       timeout: "5h"
       dependencies: [test-performance-small-grakn-cluster-background]
       command: |
+        export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
+        bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
+        
         bazel run --config=rbe //:benchmark-small -- \
           --database "Grakn Cluster 2.0" \
           --database-uri $GRABL_EXPORT_PERFORMANCE_SMALL_GRAKN_CLUSTER_URI \

--- a/BenchmarkRunner.java
+++ b/BenchmarkRunner.java
@@ -49,6 +49,7 @@ import static grakn.benchmark.common.world.World.initialise;
 public class BenchmarkRunner {
 
     final static Logger LOG = LoggerFactory.getLogger(grakn.benchmark.BenchmarkRunner.class);
+    public static final String DATABASE = "world";
 
     public static void main(String[] args) {
 
@@ -110,9 +111,12 @@ public class BenchmarkRunner {
                 if (dbName.toLowerCase().startsWith("grakn")) {
                     defaultUri = "localhost:48555";
                     if (hostUri == null) hostUri = defaultUri;
-
+                    GraknDriver graknDriver;
+                    if (dbName.toLowerCase().contains("core")) graknDriver = GraknDriver.core(hostUri, DATABASE);
+                    else if (dbName.toLowerCase().contains("cluster")) graknDriver = GraknDriver.cluster(hostUri, DATABASE);
+                    else throw new IllegalArgumentException("Unexpected database name: " + dbName);
                     benchmark = new grakn.benchmark.grakn.GraknBenchmark(
-                            new GraknDriver(hostUri, "world"),
+                            graknDriver,
                             initialisationDataFiles,
                             config.getRandomSeed(),
                             world,
@@ -132,7 +136,7 @@ public class BenchmarkRunner {
                             config.getTraceSampling().getSamplingFunction(),
                             false);
                 } else {
-                    throw new IllegalArgumentException("Unexpected value: " + dbName);
+                    throw new IllegalArgumentException("Unexpected database name: " + dbName);
                 }
 
                 ///////////////

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -156,8 +156,9 @@ graknlabs_graql()
 graknlabs_protocol()
 
 # Load artifact
-load("//dependencies/graknlabs:artifacts.bzl", "graknlabs_grakn_core_artifacts")
+load("//dependencies/graknlabs:artifacts.bzl", "graknlabs_grakn_core_artifacts", "graknlabs_grakn_cluster_artifacts")
 graknlabs_grakn_core_artifacts()
+graknlabs_grakn_cluster_artifacts()
 
 # Load maven
 load("//dependencies/maven:artifacts.bzl", graknlabs_benchmark_artifacts = "artifacts")

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -18,14 +18,24 @@
 #
 
 load("@graknlabs_dependencies//distribution/artifact:rules.bzl", "native_artifact_files")
-load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
+load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment", "deployment_private")
 
 def graknlabs_grakn_core_artifacts():
     native_artifact_files(
         name = "graknlabs_grakn_core_artifact",
         group_name = "graknlabs_grakn_core",
-        artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
+        artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
         commit = "1ca6886f8412a408cf8a4266c8923b07dd38e9ce",
+    )
+
+def graknlabs_grakn_cluster_artifacts():
+    native_artifact_files(
+        name = "graknlabs_grakn_cluster_artifact",
+        group_name = "graknlabs_grakn_cluster",
+        artifact_name = "grakn-cluster-server-{platform}-{version}.{ext}",
+        tag_source = deployment_private["artifact.release"],
+        commit_source = deployment_private["artifact.snapshot"],
+        commit = "74c7e69beca0f281528a4e27a9bca6feb033b386",
     )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-server-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "74c7e69beca0f281528a4e27a9bca6feb033b386",
+        commit = "12a4a954fd007ccdb7786b0c05b76f30a0809b6a",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -28,8 +28,8 @@ def graknlabs_dependencies():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/lolski/client-java",
-        commit = "3f5e44d5e71fea7247fccecd99438e4072c8a306",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/graknlabs/client-java",
+        commit = "9cad45c2d926f421e94969844fc1b64e0b529dbc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -28,8 +28,8 @@ def graknlabs_dependencies():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
-        commit = "9cad45c2d926f421e94969844fc1b64e0b529dbc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/lolski/client-java",
+        commit = "3f5e44d5e71fea7247fccecd99438e4072c8a306",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -29,7 +29,7 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        commit = "9cad45c2d926f421e94969844fc1b64e0b529dbc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        commit = "a1b7e8d6c1fa2103e012b76a8470611158326ace",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():

--- a/grakn/driver/GraknDriver.java
+++ b/grakn/driver/GraknDriver.java
@@ -33,7 +33,7 @@ public class GraknDriver extends TransactionalDbDriver<Grakn.Transaction, Grakn.
     private final ConcurrentHashMap<String, Grakn.Session> sessionMap = new ConcurrentHashMap<>();
 
     public GraknDriver(String hostUri, String database) {
-        this.client = GraknClient.core(hostUri);
+        this.client = GraknClient.cluster(hostUri);
         this.database = database;
     }
 

--- a/grakn/driver/GraknDriver.java
+++ b/grakn/driver/GraknDriver.java
@@ -33,6 +33,7 @@ public class GraknDriver extends TransactionalDbDriver<Grakn.Transaction, Grakn.
     private final ConcurrentHashMap<String, Grakn.Session> sessionMap = new ConcurrentHashMap<>();
 
     public GraknDriver(String hostUri, String database) {
+        System.out.println("------  " + hostUri);
         this.client = GraknClient.cluster(hostUri);
         this.database = database;
     }

--- a/grakn/driver/GraknDriver.java
+++ b/grakn/driver/GraknDriver.java
@@ -33,7 +33,6 @@ public class GraknDriver extends TransactionalDbDriver<Grakn.Transaction, Grakn.
     private final ConcurrentHashMap<String, Grakn.Session> sessionMap = new ConcurrentHashMap<>();
 
     public GraknDriver(String hostUri, String database) {
-        System.out.println("------  " + hostUri);
         this.client = GraknClient.cluster(hostUri);
         this.database = database;
     }

--- a/grakn/driver/GraknDriver.java
+++ b/grakn/driver/GraknDriver.java
@@ -41,7 +41,7 @@ public class GraknDriver extends TransactionalDbDriver<Grakn.Transaction, Grakn.
         return new GraknDriver(Either.second(GraknClient.cluster(hostUri)), database);
     }
 
-    public GraknDriver(Either<Grakn.Client, GraknClient.Cluster> client, String database) {
+    private GraknDriver(Either<Grakn.Client, GraknClient.Cluster> client, String database) {
         this.client = client;
         this.database = database;
     }

--- a/grakn/driver/GraknDriver.java
+++ b/grakn/driver/GraknDriver.java
@@ -22,43 +22,66 @@ import grakn.benchmark.common.driver.TransactionalDbDriver;
 import grakn.benchmark.common.world.Region;
 import grakn.client.Grakn;
 import grakn.client.GraknClient;
+import grakn.common.collection.Either;
 import org.slf4j.Logger;
 
 import java.util.concurrent.ConcurrentHashMap;
 
 public class GraknDriver extends TransactionalDbDriver<Grakn.Transaction, Grakn.Session, GraknOperation> {
 
-    private final Grakn.Client client;
+    private final Either<Grakn.Client, GraknClient.Cluster> client;
     private final String database;
     private final ConcurrentHashMap<String, Grakn.Session> sessionMap = new ConcurrentHashMap<>();
 
     public static GraknDriver core(String hostUri, String database) {
-        return new GraknDriver(GraknClient.core(hostUri), database);
+        return new GraknDriver(Either.first(GraknClient.core(hostUri)), database);
     }
 
     public static GraknDriver cluster(String hostUri, String database) {
-        return new GraknDriver(GraknClient.cluster(hostUri), database);
+        return new GraknDriver(Either.second(GraknClient.cluster(hostUri)), database);
     }
 
-
-    public GraknDriver(Grakn.Client client, String database) {
+    public GraknDriver(Either<Grakn.Client, GraknClient.Cluster> client, String database) {
         this.client = client;
         this.database = database;
     }
 
     public void createDatabase() {
-        if (client.databases().contains(database))
-            client.databases().delete(database);
-        client.databases().create(database);
+        if (client.apply(
+                core -> core.databases().contains(database),
+                cluster -> cluster.databases().contains(database))
+        )
+            client.apply(
+                    core -> { core.databases().delete(database); return null; },
+                    cluster -> { cluster.databases().delete(database); return null; }
+            );
+        client.apply(
+                core -> { core.databases().create(database); return null; },
+                cluster -> { cluster.databases().create(database); return null; }
+        );
     }
 
     @Override
     public Grakn.Session session(String sessionKey) {
-        return sessionMap.computeIfAbsent(sessionKey, k -> client.session(database, Grakn.Session.Type.DATA));
+        return sessionMap.computeIfAbsent(
+                sessionKey,
+                k ->
+                        client.apply(
+                                core -> core.session(database, Grakn.Session.Type.DATA),
+                                cluster -> cluster.session(database, Grakn.Session.Type.DATA)
+                        )
+        );
     }
 
     public Grakn.Session schemaSession(String sessionKey) {
-        return sessionMap.computeIfAbsent(sessionKey, k -> client.session(database, Grakn.Session.Type.SCHEMA));
+        return sessionMap.computeIfAbsent(
+                sessionKey,
+                k ->
+                        client.apply(
+                                core -> core.session(database, Grakn.Session.Type.SCHEMA),
+                                cluster -> cluster.session(database, Grakn.Session.Type.SCHEMA)
+                        )
+        );
     }
 
     @Override
@@ -72,7 +95,7 @@ public class GraknDriver extends TransactionalDbDriver<Grakn.Transaction, Grakn.
     @Override
     public void close() {
         closeSessions();
-        client.close();
+        client.apply(core -> { core.close(); return null; }, cluster -> { cluster.close(); return null; });
     }
 
     @Override

--- a/grakn/driver/GraknDriver.java
+++ b/grakn/driver/GraknDriver.java
@@ -32,8 +32,17 @@ public class GraknDriver extends TransactionalDbDriver<Grakn.Transaction, Grakn.
     private final String database;
     private final ConcurrentHashMap<String, Grakn.Session> sessionMap = new ConcurrentHashMap<>();
 
-    public GraknDriver(String hostUri, String database) {
-        this.client = GraknClient.cluster(hostUri);
+    public static GraknDriver core(String hostUri, String database) {
+        return new GraknDriver(GraknClient.core(hostUri), database);
+    }
+
+    public static GraknDriver cluster(String hostUri, String database) {
+        return new GraknDriver(GraknClient.cluster(hostUri), database);
+    }
+
+
+    public GraknDriver(Grakn.Client client, String database) {
+        this.client = client;
         this.database = database;
     }
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -21,8 +21,13 @@ load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@graknlabs_bazel_distribution//artifact:rules.bzl", "artifact_extractor")
 
 artifact_extractor(
-    name = "grakn-extractor-linux",
+    name = "grakn-core-extractor-linux",
     artifact = "@graknlabs_grakn_core_artifact_linux//file",
+)
+
+artifact_extractor(
+    name = "grakn-cluster-extractor-linux",
+    artifact = "@graknlabs_grakn_cluster_artifact_linux//file",
 )
 
 java_test(

--- a/test/BenchmarksForComparison.java
+++ b/test/BenchmarksForComparison.java
@@ -45,7 +45,7 @@ import static grakn.benchmark.config.Config.Agent.ConstructAgentConfig;
 
 public class BenchmarksForComparison {
     static final grakn.benchmark.neo4j.Neo4JBenchmark neo4j;
-    static final grakn.benchmark.grakn.GraknBenchmark grakn;
+    static final grakn.benchmark.grakn.GraknBenchmark graknCore;
     static final int numIterations = 5;
 
     static {
@@ -114,8 +114,8 @@ public class BenchmarksForComparison {
         // Grakn setup //
         /////////////////
 
-        grakn = new grakn.benchmark.grakn.GraknBenchmark(
-                new GraknDriver(graknUri, "world"),
+        graknCore = new grakn.benchmark.grakn.GraknBenchmark(
+                GraknDriver.core(graknUri, "world"),
                 files,
                 randomSeed,
                 world,

--- a/test/ComparisonTest.java
+++ b/test/ComparisonTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Iterator;
 
-import static grakn.benchmark.test.BenchmarksForComparison.grakn;
+import static grakn.benchmark.test.BenchmarksForComparison.graknCore;
 import static grakn.benchmark.test.BenchmarksForComparison.neo4j;
 import static org.junit.Assert.assertEquals;
 
@@ -33,7 +33,7 @@ public class ComparisonTest {
 
     private void compareReports(String agentName) {
 
-        Agent<?, ?>.Report graknAgentReport = grakn.getReport().getAgentReport(agentName);
+        Agent<?, ?>.Report graknAgentReport = graknCore.getReport().getAgentReport(agentName);
         Agent<?, ?>.Report neo4jAgentReport = neo4j.getReport().getAgentReport(agentName);
 
         if (!graknAgentReport.equals(neo4jAgentReport)) {

--- a/test/ComparisonTestSuite.java
+++ b/test/ComparisonTestSuite.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static grakn.benchmark.test.BenchmarksForComparison.grakn;
+import static grakn.benchmark.test.BenchmarksForComparison.graknCore;
 import static grakn.benchmark.test.BenchmarksForComparison.neo4j;
 
 public class ComparisonTestSuite extends Suite {
@@ -58,10 +58,10 @@ public class ComparisonTestSuite extends Suite {
     protected void runChild(Runner runner, final RunNotifier notifier) {
         iteration++;
         neo4j.iterate();
-        grakn.iterate();
+        graknCore.iterate();
         super.runChild(runner, notifier);
         if (iteration == BenchmarksForComparison.numIterations + 1) {
-            grakn.close();
+            graknCore.close();
             neo4j.close();
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

We have added Grakn Cluster benchmark into the CI.

## What are the changes implemented in this PR?

- Adds the ability to select whether to benchmark Grakn Core or Grakn Cluster. This is done with the `--database` option.
- Adds Grakn Cluster benchmark job.