### PR TITLE
Fix waiting for Neo4J instance

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -131,7 +131,8 @@ build:
         echo 'Trying to connect to Neo4j'
         attempt_counter=0
         max_attempts=50
-        until $(curl --output /dev/null --silent --head --fail $GRABL_EXPORT_PERFORMANCE_SMALL_NEO4J_URI); do
+        expected_exit_code=52
+        until curl --output /dev/null --silent --head --fail $GRABL_EXPORT_PERFORMANCE_SMALL_NEO4J_URI || [[ $? == $expected_exit_code ]]; do
             if [ ${attempt_counter} -eq ${max_attempts} ];then
               echo "Max attempts reached"
               exit 1


### PR DESCRIPTION
## What is the goal of this PR?

Correctly wait for Neo4J instance to become available.

## What are the changes implemented in this PR?

Wait for exit code to become 52 ("empty response")