### PR TITLE
Use self-hosted Bazel cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,11 +1,1 @@
-build:rbe --project_id=grakn-dev
-build:rbe --remote_cache=cloud.buildbuddy.io
-build:rbe --remote_executor=cloud.buildbuddy.io
-build:rbe --bes_backend=cloud.buildbuddy.io
-build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
-build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
-build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
-build:rbe --host_platform=@graknlabs_dependencies//image/buildbuddy:ubuntu-2004
-build:rbe --jobs=50
-build:rbe --remote_timeout=3600
-
+try-import /opt/credentials/bazel-remote-cache.rc


### PR DESCRIPTION
## What is the goal of this PR?

Speed up CI by using self-hosted remote Bazel cache

## What are the changes implemented in this PR?

Import `/opt/credentials/bazel-remote-cache.rc`which configures remote caching