### PR TITLE
Depend on netty borringssl from factory-tracing 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -162,8 +162,9 @@ vaticle_typedb_cluster_artifacts()
 # Load maven
 load("//dependencies/maven:artifacts.bzl", vaticle_typedb_benchmark_artifacts = "artifacts")
 load("@vaticle_typedb_client_java//dependencies/maven:artifacts.bzl", vaticle_typedb_client_java_artifacts = "artifacts")
-load("@vaticle_typeql_lang_java//dependencies/maven:artifacts.bzl", vaticle_typeql_lang_java_artifacts = "artifacts")
+load("@vaticle_factory_tracing//dependencies/maven:artifacts.bzl", vaticle_factory_tracing_artifacts = "artifacts")
 load("@vaticle_typedb_protocol//dependencies/maven:artifacts.bzl", vaticle_typedb_protocol_artifacts = "artifacts")
+load("@vaticle_typeql_lang_java//dependencies/maven:artifacts.bzl", vaticle_typeql_lang_java_artifacts = "artifacts")
 
 # Load neo4j
 load("@rules_jvm_external//:defs.bzl", rje_maven_install = "maven_install")
@@ -186,5 +187,6 @@ maven(
     vaticle_typedb_benchmark_artifacts +
     vaticle_typeql_lang_java_artifacts +
     vaticle_typedb_protocol_artifacts +
-    vaticle_typedb_client_java_artifacts
+    vaticle_typedb_client_java_artifacts +
+    vaticle_factory_tracing_artifacts
 )

--- a/dependencies/maven/artifacts.bzl
+++ b/dependencies/maven/artifacts.bzl
@@ -18,7 +18,6 @@
 artifacts = [
   "com.google.code.findbugs:jsr305",
   "info.picocli:picocli",
-  "io.netty:netty-tcnative-boringssl-static",
   "junit:junit",
   "org.apache.commons:commons-csv",
   "org.slf4j:slf4j-api",


### PR DESCRIPTION
## What is the goal of this PR?

We now correctly import an ssl dependency `factory-tracing` instead of redeclaring it as a top-level maven dependency.

## What are the changes implemented in this PR?

* remove netty borringssl from direct maven deps
* depend on netty boringssl via factory-tracing