### PR TITLE
Fix report collection for comparison test

### DIFF
--- a/simulation/Simulation.java
+++ b/simulation/Simulation.java
@@ -56,7 +56,7 @@ public abstract class Simulation<
     protected final Context context;
     private final RandomSource randomSource;
     private final List<Agent<?, TX>> agents;
-    private final Map<Class<? extends Agent>, Map<String, List<Agent.Report>>> agentReports;
+    private final Map<String, Map<String, List<Agent.Report>>> agentReports;
 
     public Simulation(CLIENT client, Context context) throws Exception {
         this.client = client;
@@ -93,7 +93,9 @@ public abstract class Simulation<
     }
 
     public Map<String, List<Agent.Report>> getReport(Class<? extends Agent> agentName) {
-        return agentReports.get(agentName);
+        Map<String, List<Agent.Report>> report = agentReports.get(agentName.getSimpleName());
+        assert report != null;
+        return report;
     }
 
     public void run() {
@@ -111,7 +113,7 @@ public abstract class Simulation<
 
     public void iterate() {
         agentReports.clear();
-        agents.forEach(agent -> agentReports.put(agent.getClass(), agent.iterate(randomSource.nextSource())));
+        agents.forEach(agent -> agentReports.put(agent.getClass().getSuperclass().getSimpleName(), agent.iterate(randomSource.nextSource())));
         context.incrementIteration();
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

Fix the collecting of reports for comparison testing.

## What are the changes implemented in this PR?

Agent reports are now stored by the simple name of the parent class. e.g. a report for `TypeDBPersonAgent` will be stored in the map of reports with the key `PersonAgent` so that the comparison test can easily find it based on the list of registered agents.