### PR TITLE
Extend license checkstyle tests and update licenses

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -25,7 +25,7 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel build //...
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
+        bazel test $(bazel query 'kind(kt_jvm_test, attr(generator_function, checkstyle_test, //...))') --test_output=streamed
     build-dependency:
       image: vaticle-ubuntu-21.04
       command: |

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -25,7 +25,7 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel build //...
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(kt_jvm_test, attr(generator_function, checkstyle_test, //...))') --test_output=streamed
+        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
     build-dependency:
       image: vaticle-ubuntu-21.04
       command: |

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/BUILD
+++ b/BUILD
@@ -43,6 +43,17 @@ java_binary(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", ".grabl/*"]),
-    exclude = glob(["docs/*"]),
-    license_type = "agpl",
+    exclude = glob([
+        ".bazelversion",
+        "LICENSE",
+        "README.md",
+        "docs/*",
+    ]),
+    license_type = "agpl-header",
+)
+
+checkstyle_test(
+    name = "checkstyle-license",
+    include = ["LICENSE"],
+    license_type = "agpl-fulltext",
 )

--- a/Benchmark.java
+++ b/Benchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -150,13 +150,10 @@ bind(
 load("//dependencies/vaticle:repositories.bzl", "vaticle_factory_tracing", "vaticle_typedb_client_java")
 vaticle_factory_tracing()
 vaticle_typedb_client_java()
-load("@vaticle_typedb_client_java//dependencies/vaticle:repositories.bzl", "vaticle_typedb_common", "vaticle_typeql_lang_java", "vaticle_typedb_protocol")
+load("@vaticle_typedb_client_java//dependencies/vaticle:repositories.bzl", "vaticle_typedb_common", "vaticle_typeql", "vaticle_typedb_protocol")
 vaticle_typedb_common()
-vaticle_typeql_lang_java()
-vaticle_typedb_protocol()
-
-load("@vaticle_typeql_lang_java//dependencies/vaticle:repositories.bzl", "vaticle_typeql")
 vaticle_typeql()
+vaticle_typedb_protocol()
 
 # Load artifact
 load("//dependencies/vaticle:artifacts.bzl", "vaticle_typedb_artifacts", "vaticle_typedb_cluster_artifacts")
@@ -168,7 +165,7 @@ load("//dependencies/maven:artifacts.bzl", vaticle_typedb_benchmark_artifacts = 
 load("@vaticle_typedb_client_java//dependencies/maven:artifacts.bzl", vaticle_typedb_client_java_artifacts = "artifacts")
 load("@vaticle_factory_tracing//dependencies/maven:artifacts.bzl", vaticle_factory_tracing_artifacts = "artifacts")
 load("@vaticle_typedb_protocol//dependencies/maven:artifacts.bzl", vaticle_typedb_protocol_artifacts = "artifacts")
-load("@vaticle_typeql_lang_java//dependencies/maven:artifacts.bzl", vaticle_typeql_lang_java_artifacts = "artifacts")
+load("@vaticle_typeql//dependencies/maven:artifacts.bzl", vaticle_typeql_artifacts = "artifacts")
 
 # Load neo4j
 load("@rules_jvm_external//:defs.bzl", "maven_install")
@@ -189,7 +186,7 @@ maven_install(
 load("@vaticle_dependencies//library/maven:rules.bzl", "maven")
 maven(
     vaticle_typedb_benchmark_artifacts +
-    vaticle_typeql_lang_java_artifacts +
+    vaticle_typeql_artifacts +
     vaticle_typedb_protocol_artifacts +
     vaticle_typedb_client_java_artifacts +
     vaticle_factory_tracing_artifacts

--- a/common/BUILD
+++ b/common/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/common/BUILD
+++ b/common/BUILD
@@ -37,5 +37,5 @@ java_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
-    license_type = "agpl"
+    license_type = "agpl-header",
 )

--- a/common/Util.java
+++ b/common/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/concept/City.java
+++ b/common/concept/City.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/concept/Continent.java
+++ b/common/concept/Continent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/concept/Country.java
+++ b/common/concept/Country.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/concept/Currency.java
+++ b/common/concept/Currency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/concept/Gender.java
+++ b/common/concept/Gender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/concept/Global.java
+++ b/common/concept/Global.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/concept/Marriage.java
+++ b/common/concept/Marriage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/concept/Parenthood.java
+++ b/common/concept/Parenthood.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/concept/Person.java
+++ b/common/concept/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/concept/Region.java
+++ b/common/concept/Region.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/concept/University.java
+++ b/common/concept/University.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/params/Config.java
+++ b/common/params/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/params/Context.java
+++ b/common/params/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/params/DatabaseType.java
+++ b/common/params/DatabaseType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/params/Options.java
+++ b/common/params/Options.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/seed/RandomSource.java
+++ b/common/seed/RandomSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/common/seed/SeedData.java
+++ b/common/seed/SeedData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/config/BUILD
+++ b/config/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/config/BUILD
+++ b/config/BUILD
@@ -24,5 +24,5 @@ exports_files([
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/config/logback.xml
+++ b/config/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2021 Vaticle
+  ~ Copyright (C) 2022 Vaticle
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU Affero General Public License as

--- a/config/simulation.yml
+++ b/config/simulation.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/config/simulation_reasoning.yml
+++ b/config/simulation_reasoning.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/data/BUILD
+++ b/data/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/data/BUILD
+++ b/data/BUILD
@@ -38,5 +38,5 @@ checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
     exclude = glob(["*.csv"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/dependencies/maven/BUILD
+++ b/dependencies/maven/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/dependencies/maven/BUILD
+++ b/dependencies/maven/BUILD
@@ -21,5 +21,5 @@ checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
     exclude = ["artifacts.snapshot"],
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/dependencies/maven/artifacts.bzl
+++ b/dependencies/maven/artifacts.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/dependencies/maven/update.sh
+++ b/dependencies/maven/update.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/dependencies/vaticle/BUILD
+++ b/dependencies/vaticle/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/dependencies/vaticle/BUILD
+++ b/dependencies/vaticle/BUILD
@@ -20,5 +20,5 @@ load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,19 +21,19 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "57617a9978129f5d6b50f69146caaa9e86c3c85e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "6904ecb83c744097ef993f29f9941d55538ab331",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
         remote = "https://github.com/vaticle/typedb-client-java",
-        commit = "743c130a60414e78133f42c08e4d546bc73bc471",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "9ed76321aa717bff76f7e5575d1975b02275119b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )
 
 def vaticle_factory_tracing():
     git_repository(
         name = "vaticle_factory_tracing",
         remote = "https://github.com/vaticle/factory-tracing",
-        commit = "7b4a3933139af670a7b7c925fc20de40d63caa41"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
+        commit = "272fe454a58b5222ea27ea49a4b3449971a64def"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "6904ecb83c744097ef993f29f9941d55538ab331",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "ecadc48b881b373f055c981505a58a02c2decb9b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_client_java():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,19 +21,19 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "ecadc48b881b373f055c981505a58a02c2decb9b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "a8b3b714a5e0562d41f4c05ca8f266d48b7d0fd3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
         remote = "https://github.com/vaticle/typedb-client-java",
-        commit = "9ed76321aa717bff76f7e5575d1975b02275119b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "5717b9cb0c63e0e1c4457ad8e5ad5141d3f04556",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )
 
 def vaticle_factory_tracing():
     git_repository(
         name = "vaticle_factory_tracing",
         remote = "https://github.com/vaticle/factory-tracing",
-        commit = "272fe454a58b5222ea27ea49a4b3449971a64def"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
+        commit = "a4d5e36b1b0c56bd370e5a7583d628de9272f086"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "34c260ae7858b08dd6247d43c8c373847b113d68",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "57617a9978129f5d6b50f69146caaa9e86c3c85e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_client_java():

--- a/docs/deps.sh
+++ b/docs/deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/logsplit.py
+++ b/logsplit.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neo4j/BUILD
+++ b/neo4j/BUILD
@@ -33,5 +33,5 @@ java_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*", "*/*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/neo4j/BUILD
+++ b/neo4j/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neo4j/Labels.java
+++ b/neo4j/Labels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/neo4j/Neo4JSimulation.java
+++ b/neo4j/Neo4JSimulation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/neo4j/agent/Neo4jFriendshipAgent.java
+++ b/neo4j/agent/Neo4jFriendshipAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/neo4j/agent/Neo4jMarriageAgent.java
+++ b/neo4j/agent/Neo4jMarriageAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/neo4j/agent/Neo4jParenthoodAgent.java
+++ b/neo4j/agent/Neo4jParenthoodAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/neo4j/agent/Neo4jPersonAgent.java
+++ b/neo4j/agent/Neo4jPersonAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/neo4j/driver/Neo4jClient.java
+++ b/neo4j/driver/Neo4jClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/neo4j/driver/Neo4jSession.java
+++ b/neo4j/driver/Neo4jSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/neo4j/driver/Neo4jTransaction.java
+++ b/neo4j/driver/Neo4jTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/report/BUILD
+++ b/report/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/report/BUILD
+++ b/report/BUILD
@@ -57,5 +57,5 @@ checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "plots/*.py"]),
     exclude = glob(["templates/*", "plots/requirements.txt"]),
-    license_type = "agpl"
+    license_type = "agpl-header",
 )

--- a/report/Report.groovy
+++ b/report/Report.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/report/plots/line_chart.py
+++ b/report/plots/line_chart.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/report/plots/overview_chart.py
+++ b/report/plots/overview_chart.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/report/plots/report_plots.py
+++ b/report/plots/report_plots.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/simulation/BUILD
+++ b/simulation/BUILD
@@ -32,5 +32,5 @@ java_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/simulation/BUILD
+++ b/simulation/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/simulation/Simulation.java
+++ b/simulation/Simulation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/agent/Agent.java
+++ b/simulation/agent/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/agent/CitizenshipAgent.java
+++ b/simulation/agent/CitizenshipAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/agent/CoupleFriendshipAgent.java
+++ b/simulation/agent/CoupleFriendshipAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/agent/FriendshipAgent.java
+++ b/simulation/agent/FriendshipAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/agent/GrandparenthoodAgent.java
+++ b/simulation/agent/GrandparenthoodAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/agent/LineageAgent.java
+++ b/simulation/agent/LineageAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/agent/MaritalStatusAgent.java
+++ b/simulation/agent/MaritalStatusAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/agent/MarriageAgent.java
+++ b/simulation/agent/MarriageAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/agent/NationalityAgent.java
+++ b/simulation/agent/NationalityAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/agent/ParenthoodAgent.java
+++ b/simulation/agent/ParenthoodAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/agent/PersonAgent.java
+++ b/simulation/agent/PersonAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/driver/Client.java
+++ b/simulation/driver/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/driver/Session.java
+++ b/simulation/driver/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/simulation/driver/Transaction.java
+++ b/simulation/driver/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/test/BUILD
+++ b/test/BUILD
@@ -48,5 +48,5 @@ java_test(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl"
+    license_type = "agpl-header",
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/test/ComparisonTest.java
+++ b/test/ComparisonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/test/comparison-test.yml
+++ b/test/comparison-test.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/typedb/BUILD
+++ b/typedb/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/typedb/BUILD
+++ b/typedb/BUILD
@@ -27,9 +27,9 @@ java_library(
         "@vaticle_typedb_client_java//api:api",
         "@vaticle_typedb_client_java//:client-java",
         "@vaticle_typedb_common//:common",
-        "@vaticle_typeql_lang_java//:typeql-lang",
-        "@vaticle_typeql_lang_java//pattern:pattern",
-        "@vaticle_typeql_lang_java//query:query",
+        "@vaticle_typeql//java:typeql-lang",
+        "@vaticle_typeql//java/pattern:pattern",
+        "@vaticle_typeql//java/query:query",
         "@maven//:org_slf4j_slf4j_api",
     ],
     data = ["simulation.tql"],
@@ -38,5 +38,5 @@ java_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*", "*/*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/typedb/Labels.java
+++ b/typedb/Labels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/TypeDBSimulation.java
+++ b/typedb/TypeDBSimulation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/agent/TypeDBCitizenshipAgent.java
+++ b/typedb/agent/TypeDBCitizenshipAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/agent/TypeDBCoupleFriendshipAgent.java
+++ b/typedb/agent/TypeDBCoupleFriendshipAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/agent/TypeDBFriendshipAgent.java
+++ b/typedb/agent/TypeDBFriendshipAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/agent/TypeDBGrandParenthoodAgent.java
+++ b/typedb/agent/TypeDBGrandParenthoodAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/agent/TypeDBLineageAgent.java
+++ b/typedb/agent/TypeDBLineageAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/agent/TypeDBMaritalStatusAgent.java
+++ b/typedb/agent/TypeDBMaritalStatusAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/agent/TypeDBMarriageAgent.java
+++ b/typedb/agent/TypeDBMarriageAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/agent/TypeDBNationalityAgent.java
+++ b/typedb/agent/TypeDBNationalityAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/agent/TypeDBParenthoodAgent.java
+++ b/typedb/agent/TypeDBParenthoodAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/agent/TypeDBPersonAgent.java
+++ b/typedb/agent/TypeDBPersonAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/driver/TypeDBClient.java
+++ b/typedb/driver/TypeDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/driver/TypeDBSession.java
+++ b/typedb/driver/TypeDBSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/driver/TypeDBTransaction.java
+++ b/typedb/driver/TypeDBTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typedb/simulation.tql
+++ b/typedb/simulation.tql
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
## What is the goal of this PR?

We update the copyright header year to 2022, and introduce a test that ensures that the license text is correct.

## What are the changes implemented in this PR?

* Replace the year 2021 with 2022 in each copyright header;
* Bring all the `checkstyle_test()` invocations in line with the updated definition in dependencies;
* Replace all references to `typeql-lang-java` with `typeql/java`;
* Use checkstyle to confirm that the license text is correct.
