### PR TITLE
Restore Neo4J benchmark and deactivated factory-tracing

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -117,10 +117,67 @@ build:
       dependencies: [test-performance-typedb-core-server]
       timeout: "30m"
       command: |
-       bazel run //:benchmark -- \
-         --database typedb \
-         --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CORE_URI \
-         --config /home/grabl/$GRABL_REPO/config/simulation.yml
+        bazel run //:benchmark -- \
+          --database typedb \
+          --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CORE_URI \
+          --config /home/grabl/$GRABL_REPO/config/simulation.yml \
+          --factory $GRABL_TRACING_URI \
+          --org $GRABL_OWNER \
+          --repo $GRABL_REPO \
+          --commit $GRABL_COMMIT \
+          --username $GRABL_OWNER \
+          --token $GRABL_TOKEN
+    test-performance-neo4j-server:
+      machine: 16-core-32-gb
+      image: vaticle-ubuntu-21.04
+      type: background
+      timeout: "30m"
+      monitor: |
+        journalctl -fu neo4j
+      command: |
+        sudo add-apt-repository -y ppa:openjdk-r/ppa
+        curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
+        curl https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+        sudo apt-get update
+        wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
+        echo 'deb https://debian.neo4j.com stable 4.2' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
+        sudo apt-get update
+        sudo apt-get install -y neo4j=1:4.2.5
+        sudo update-java-alternatives --jre --set java-1.11.0-openjdk-amd64
+        echo 'dbms.connector.bolt.listen_address=0.0.0.0:7687' | sudo tee -a /etc/neo4j/neo4j.conf
+        echo 'dbms.security.auth_enabled=false' | sudo tee -a /etc/neo4j/neo4j.conf
+        echo 'dbms.memory.heap.max_size=24G' | sudo tee -a /etc/neo4j/neo4j.conf
+        sudo systemctl restart neo4j
+        export GRABL_EXPORT_PERFORMANCE_NEO4J_URI="${HOSTNAME}:7687"
+    test-performance-neo4j-benchmark:
+      machine: 16-core-32-gb
+      image: vaticle-ubuntu-21.04
+      dependencies: [ test-performance-neo4j-server ]
+      timeout: "30m"
+      command: |
+        echo 'Trying to connect to Neo4j'
+        attempt_counter=0
+        max_attempts=50
+        expected_exit_code=52
+        until curl --output /dev/null --silent --head --fail $GRABL_EXPORT_PERFORMANCE_NEO4J_URI || [[ $? == $expected_exit_code ]]; do
+            if [ ${attempt_counter} -eq ${max_attempts} ];then
+              echo "Max attempts reached"
+              exit 1
+            fi
+            echo '...'
+            attempt_counter=$(($attempt_counter+1))
+            sleep 3
+        done
+        bazel run //:benchmark -- \
+          --database neo4j \
+          --address bolt://$GRABL_EXPORT_PERFORMANCE_NEO4J_URI \
+          --config /home/grabl/$GRABL_REPO/config/simulation.yml \
+          --factory $GRABL_TRACING_URI \
+          --org $GRABL_OWNER \
+          --repo $GRABL_REPO \
+          --commit $GRABL_COMMIT \
+          --username $GRABL_OWNER \
+          --token $GRABL_TOKEN
     test-performance-typedb-cluster-one-server:
       machine: 16-core-32-gb
       image: vaticle-ubuntu-21.04

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -120,13 +120,7 @@ build:
         bazel run //:benchmark -- \
           --database typedb \
           --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CORE_URI \
-          --config /home/grabl/$GRABL_REPO/config/simulation.yml \
-          --factory $GRABL_TRACING_URI \
-          --org $GRABL_OWNER \
-          --repo $GRABL_REPO \
-          --commit $GRABL_COMMIT \
-          --username $GRABL_OWNER \
-          --token $GRABL_TOKEN
+          --config /home/grabl/$GRABL_REPO/config/simulation.yml
     test-performance-neo4j-server:
       machine: 16-core-32-gb
       image: vaticle-ubuntu-21.04
@@ -171,189 +165,183 @@ build:
         bazel run //:benchmark -- \
           --database neo4j \
           --address bolt://$GRABL_EXPORT_PERFORMANCE_NEO4J_URI \
-          --config /home/grabl/$GRABL_REPO/config/simulation.yml \
-          --factory $GRABL_TRACING_URI \
-          --org $GRABL_OWNER \
-          --repo $GRABL_REPO \
-          --commit $GRABL_COMMIT \
-          --username $GRABL_OWNER \
-          --token $GRABL_TOKEN
-    test-performance-typedb-cluster-one-server:
-      machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
-      type: background
-      timeout: "30m"
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        bazel run //test:typedb-cluster-extractor-linux -- dist/typedb-cluster-all-linux
-        bazel run @vaticle_dependencies//tool/util:create-systemd-service -- typedb-cluster "\/home\/grabl\/$GRABL_REPO\/dist\/typedb-cluster-all-linux\/typedb cluster --server.address=${HOSTNAME}:1729"
-
-        sudo systemctl daemon-reload
-        sudo systemctl start typedb-cluster
-
-        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI="${HOSTNAME}:1729"
-      monitor: |
-        sleep 20s
-        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
-    test-performance-typedb-cluster-one-benchmark:
-      machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
-      dependencies: [test-performance-typedb-cluster-one-server]
-      timeout: "30m"
-      command: |
-       bazel run //:benchmark -- \
-         --database typedb-cluster \
-         --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI \
-         --config /home/grabl/$GRABL_REPO/config/simulation.yml
-    test-performance-typedb-cluster-three-bootstrapper:
-      image: vaticle-ubuntu-21.04
-      type: background
-      command: |
-        bazel run @vaticle_dependencies//tool/util:install-ssh-credential
-        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_BOOTSTRAPPER_URI="${HOSTNAME}"
-
-      monitor: |
-        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-1.txt
-        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-2.txt
-        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-3.txt
-
-        # to server 1
-        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-2.txt grabl@$(cat /tmp/typedb-cluster-server-1.txt):/tmp/typedb-cluster-server-2.txt
-        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-3.txt grabl@$(cat /tmp/typedb-cluster-server-1.txt):/tmp/typedb-cluster-server-3.txt
-        
-        # to server 2
-        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-1.txt grabl@$(cat /tmp/typedb-cluster-server-2.txt):/tmp/typedb-cluster-server-1.txt
-        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-3.txt grabl@$(cat /tmp/typedb-cluster-server-2.txt):/tmp/typedb-cluster-server-3.txt
-
-        # to server 3
-        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-1.txt grabl@$(cat /tmp/typedb-cluster-server-3.txt):/tmp/typedb-cluster-server-1.txt
-        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-2.txt grabl@$(cat /tmp/typedb-cluster-server-3.txt):/tmp/typedb-cluster-server-2.txt
-
-        sleep 1800
-    test-performance-typedb-cluster-three-server-1:
-      machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
-      type: background
-      dependencies: [test-performance-typedb-cluster-three-bootstrapper]
-      timeout: "30m"
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        bazel run @vaticle_dependencies//tool/util:install-ssh-credential
-
-        echo -n "${HOSTNAME}" > /tmp/typedb-cluster-server-1.txt
-        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-1.txt \
-          grabl@$GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_BOOTSTRAPPER_URI:/tmp/typedb-cluster-server-1.txt
-
-        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-2.txt
-        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-3.txt
-
-        bazel run //test:typedb-cluster-extractor-linux -- dist/typedb-cluster-all-linux
-        PEER_1=$(cat /tmp/typedb-cluster-server-1.txt)
-        PEER_2=$(cat /tmp/typedb-cluster-server-2.txt)
-        PEER_3=$(cat /tmp/typedb-cluster-server-3.txt)
-        export BIN="\/home\/grabl\/$GRABL_REPO\/dist\/typedb-cluster-all-linux\/typedb cluster"
-        export OPTS_ADDR="--server.address=$PEER_1:1729 --server.internal-address.zeromq=$PEER_1:1730 --server.internal-address.grpc=$PEER_1:1731"
-        export OPTS_PEER_1="--server.peers.peer-1.address=$PEER_1:1729 --server.peers.peer-1.internal-address.zeromq=$PEER_1:1730 --server.peers.peer-1.internal-address.grpc=$PEER_1:1731"
-        export OPTS_PEER_2="--server.peers.peer-2.address=$PEER_2:1729 --server.peers.peer-2.internal-address.zeromq=$PEER_2:1730 --server.peers.peer-2.internal-address.grpc=$PEER_2:1731"
-        export OPTS_PEER_3="--server.peers.peer-3.address=$PEER_3:1729 --server.peers.peer-3.internal-address.zeromq=$PEER_3:1730 --server.peers.peer-3.internal-address.grpc=$PEER_3:1731"
-        bazel run @vaticle_dependencies//tool/util:create-systemd-service -- typedb-cluster "$BIN $OPTS_ADDR $OPTS_PEER_1 $OPTS_PEER_2 $OPTS_PEER_3"
-
-        sudo systemctl daemon-reload
-        sudo systemctl start typedb-cluster
-
-        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI="${HOSTNAME}:1729"
-      monitor: |
-        sleep 20s
-        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
-    test-performance-typedb-cluster-three-server-2:
-      machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
-      type: background
-      dependencies: [test-performance-typedb-cluster-three-bootstrapper]
-      timeout: "30m"
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        bazel run @vaticle_dependencies//tool/util:install-ssh-credential
-
-        echo -n "${HOSTNAME}" > /tmp/typedb-cluster-server-2.txt
-        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-2.txt \
-          grabl@$GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_BOOTSTRAPPER_URI:/tmp/typedb-cluster-server-2.txt
-
-        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-1.txt
-        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-3.txt
-
-        bazel run //test:typedb-cluster-extractor-linux -- dist/typedb-cluster-all-linux
-        PEER_1=$(cat /tmp/typedb-cluster-server-1.txt)
-        PEER_2=$(cat /tmp/typedb-cluster-server-2.txt)
-        PEER_3=$(cat /tmp/typedb-cluster-server-3.txt)
-        export BIN="\/home\/grabl\/$GRABL_REPO\/dist\/typedb-cluster-all-linux\/typedb cluster"
-        export OPTS_ADDR="--server.address=$PEER_2:1729 --server.internal-address.zeromq=$PEER_2:1730 --server.internal-address.grpc=$PEER_2:1731"
-        export OPTS_PEER_1="--server.peers.peer-1.address=$PEER_1:1729 --server.peers.peer-1.internal-address.zeromq=$PEER_1:1730 --server.peers.peer-1.internal-address.grpc=$PEER_1:1731"
-        export OPTS_PEER_2="--server.peers.peer-2.address=$PEER_2:1729 --server.peers.peer-2.internal-address.zeromq=$PEER_2:1730 --server.peers.peer-2.internal-address.grpc=$PEER_2:1731"
-        export OPTS_PEER_3="--server.peers.peer-3.address=$PEER_3:1729 --server.peers.peer-3.internal-address.zeromq=$PEER_3:1730 --server.peers.peer-3.internal-address.grpc=$PEER_3:1731"
-        bazel run @vaticle_dependencies//tool/util:create-systemd-service -- typedb-cluster "$BIN $OPTS_ADDR $OPTS_PEER_1 $OPTS_PEER_2 $OPTS_PEER_3"
-
-        sudo systemctl daemon-reload
-        sudo systemctl start typedb-cluster
-
-        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI="${HOSTNAME}:1729"
-      monitor: |
-        sleep 20s
-        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
-    test-performance-typedb-cluster-three-server-3:
-      machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
-      type: background
-      dependencies: [test-performance-typedb-cluster-three-bootstrapper]
-      timeout: "30m"
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        bazel run @vaticle_dependencies//tool/util:install-ssh-credential
-
-        echo -n "${HOSTNAME}" > /tmp/typedb-cluster-server-3.txt
-        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-3.txt \
-          grabl@$GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_BOOTSTRAPPER_URI:/tmp/typedb-cluster-server-3.txt
-
-        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-1.txt
-        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-2.txt
-
-        bazel run //test:typedb-cluster-extractor-linux -- dist/typedb-cluster-all-linux
-        PEER_1=$(cat /tmp/typedb-cluster-server-1.txt)
-        PEER_2=$(cat /tmp/typedb-cluster-server-2.txt)
-        PEER_3=$(cat /tmp/typedb-cluster-server-3.txt)
-        export BIN="\/home\/grabl\/$GRABL_REPO\/dist\/typedb-cluster-all-linux\/typedb cluster"
-        export OPTS_ADDR="--server.address=$PEER_3:1729 --server.internal-address.zeromq=$PEER_3:1730 --server.internal-address.grpc=$PEER_3:1731"
-        export OPTS_PEER_1="--server.peers.peer-1.address=$PEER_1:1729 --server.peers.peer-1.internal-address.zeromq=$PEER_1:1730 --server.peers.peer-1.internal-address.grpc=$PEER_1:1731"
-        export OPTS_PEER_2="--server.peers.peer-2.address=$PEER_2:1729 --server.peers.peer-2.internal-address.zeromq=$PEER_2:1730 --server.peers.peer-2.internal-address.grpc=$PEER_2:1731"
-        export OPTS_PEER_3="--server.peers.peer-3.address=$PEER_3:1729 --server.peers.peer-3.internal-address.zeromq=$PEER_3:1730 --server.peers.peer-3.internal-address.grpc=$PEER_3:1731"
-        bazel run @vaticle_dependencies//tool/util:create-systemd-service -- typedb-cluster "$BIN $OPTS_ADDR $OPTS_PEER_1 $OPTS_PEER_2 $OPTS_PEER_3"
-
-        sudo systemctl daemon-reload
-        sudo systemctl start typedb-cluster
-
-        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI="${HOSTNAME}:1729"
-      monitor: |
-        sleep 20s
-        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
-    test-performance-typedb-cluster-three-benchmark:
-      machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
-      dependencies: [test-performance-typedb-cluster-three-server-1, test-performance-typedb-cluster-three-server-2, test-performance-typedb-cluster-three-server-3]
-      timeout: "30m"
-      command: |
-       bazel run //:benchmark -- \
-         --database typedb-cluster \
-         --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI \
-         --config /home/grabl/$GRABL_REPO/config/simulation.yml
+          --config /home/grabl/$GRABL_REPO/config/simulation.yml
+#    test-performance-typedb-cluster-one-server:
+#      machine: 16-core-32-gb
+#      image: vaticle-ubuntu-21.04
+#      type: background
+#      timeout: "30m"
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        bazel run //test:typedb-cluster-extractor-linux -- dist/typedb-cluster-all-linux
+#        bazel run @vaticle_dependencies//tool/util:create-systemd-service -- typedb-cluster "\/home\/grabl\/$GRABL_REPO\/dist\/typedb-cluster-all-linux\/typedb cluster --server.address=${HOSTNAME}:1729"
+#
+#        sudo systemctl daemon-reload
+#        sudo systemctl start typedb-cluster
+#
+#        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI="${HOSTNAME}:1729"
+#      monitor: |
+#        sleep 20s
+#        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
+#    test-performance-typedb-cluster-one-benchmark:
+#      machine: 16-core-32-gb
+#      image: vaticle-ubuntu-21.04
+#      dependencies: [test-performance-typedb-cluster-one-server]
+#      timeout: "30m"
+#      command: |
+#       bazel run //:benchmark -- \
+#         --database typedb-cluster \
+#         --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI \
+#         --config /home/grabl/$GRABL_REPO/config/simulation.yml
+#    test-performance-typedb-cluster-three-bootstrapper:
+#      image: vaticle-ubuntu-21.04
+#      type: background
+#      command: |
+#        bazel run @vaticle_dependencies//tool/util:install-ssh-credential
+#        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_BOOTSTRAPPER_URI="${HOSTNAME}"
+#
+#      monitor: |
+#        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-1.txt
+#        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-2.txt
+#        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-3.txt
+#
+#        # to server 1
+#        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-2.txt grabl@$(cat /tmp/typedb-cluster-server-1.txt):/tmp/typedb-cluster-server-2.txt
+#        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-3.txt grabl@$(cat /tmp/typedb-cluster-server-1.txt):/tmp/typedb-cluster-server-3.txt
+#
+#        # to server 2
+#        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-1.txt grabl@$(cat /tmp/typedb-cluster-server-2.txt):/tmp/typedb-cluster-server-1.txt
+#        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-3.txt grabl@$(cat /tmp/typedb-cluster-server-2.txt):/tmp/typedb-cluster-server-3.txt
+#
+#        # to server 3
+#        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-1.txt grabl@$(cat /tmp/typedb-cluster-server-3.txt):/tmp/typedb-cluster-server-1.txt
+#        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-2.txt grabl@$(cat /tmp/typedb-cluster-server-3.txt):/tmp/typedb-cluster-server-2.txt
+#
+#        sleep 1800
+#    test-performance-typedb-cluster-three-server-1:
+#      machine: 16-core-32-gb
+#      image: vaticle-ubuntu-21.04
+#      type: background
+#      dependencies: [test-performance-typedb-cluster-three-bootstrapper]
+#      timeout: "30m"
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        bazel run @vaticle_dependencies//tool/util:install-ssh-credential
+#
+#        echo -n "${HOSTNAME}" > /tmp/typedb-cluster-server-1.txt
+#        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-1.txt \
+#          grabl@$GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_BOOTSTRAPPER_URI:/tmp/typedb-cluster-server-1.txt
+#
+#        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-2.txt
+#        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-3.txt
+#
+#        bazel run //test:typedb-cluster-extractor-linux -- dist/typedb-cluster-all-linux
+#        PEER_1=$(cat /tmp/typedb-cluster-server-1.txt)
+#        PEER_2=$(cat /tmp/typedb-cluster-server-2.txt)
+#        PEER_3=$(cat /tmp/typedb-cluster-server-3.txt)
+#        export BIN="\/home\/grabl\/$GRABL_REPO\/dist\/typedb-cluster-all-linux\/typedb cluster"
+#        export OPTS_ADDR="--server.address=$PEER_1:1729 --server.internal-address.zeromq=$PEER_1:1730 --server.internal-address.grpc=$PEER_1:1731"
+#        export OPTS_PEER_1="--server.peers.peer-1.address=$PEER_1:1729 --server.peers.peer-1.internal-address.zeromq=$PEER_1:1730 --server.peers.peer-1.internal-address.grpc=$PEER_1:1731"
+#        export OPTS_PEER_2="--server.peers.peer-2.address=$PEER_2:1729 --server.peers.peer-2.internal-address.zeromq=$PEER_2:1730 --server.peers.peer-2.internal-address.grpc=$PEER_2:1731"
+#        export OPTS_PEER_3="--server.peers.peer-3.address=$PEER_3:1729 --server.peers.peer-3.internal-address.zeromq=$PEER_3:1730 --server.peers.peer-3.internal-address.grpc=$PEER_3:1731"
+#        bazel run @vaticle_dependencies//tool/util:create-systemd-service -- typedb-cluster "$BIN $OPTS_ADDR $OPTS_PEER_1 $OPTS_PEER_2 $OPTS_PEER_3"
+#
+#        sudo systemctl daemon-reload
+#        sudo systemctl start typedb-cluster
+#
+#        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI="${HOSTNAME}:1729"
+#      monitor: |
+#        sleep 20s
+#        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
+#    test-performance-typedb-cluster-three-server-2:
+#      machine: 16-core-32-gb
+#      image: vaticle-ubuntu-21.04
+#      type: background
+#      dependencies: [test-performance-typedb-cluster-three-bootstrapper]
+#      timeout: "30m"
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        bazel run @vaticle_dependencies//tool/util:install-ssh-credential
+#
+#        echo -n "${HOSTNAME}" > /tmp/typedb-cluster-server-2.txt
+#        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-2.txt \
+#          grabl@$GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_BOOTSTRAPPER_URI:/tmp/typedb-cluster-server-2.txt
+#
+#        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-1.txt
+#        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-3.txt
+#
+#        bazel run //test:typedb-cluster-extractor-linux -- dist/typedb-cluster-all-linux
+#        PEER_1=$(cat /tmp/typedb-cluster-server-1.txt)
+#        PEER_2=$(cat /tmp/typedb-cluster-server-2.txt)
+#        PEER_3=$(cat /tmp/typedb-cluster-server-3.txt)
+#        export BIN="\/home\/grabl\/$GRABL_REPO\/dist\/typedb-cluster-all-linux\/typedb cluster"
+#        export OPTS_ADDR="--server.address=$PEER_2:1729 --server.internal-address.zeromq=$PEER_2:1730 --server.internal-address.grpc=$PEER_2:1731"
+#        export OPTS_PEER_1="--server.peers.peer-1.address=$PEER_1:1729 --server.peers.peer-1.internal-address.zeromq=$PEER_1:1730 --server.peers.peer-1.internal-address.grpc=$PEER_1:1731"
+#        export OPTS_PEER_2="--server.peers.peer-2.address=$PEER_2:1729 --server.peers.peer-2.internal-address.zeromq=$PEER_2:1730 --server.peers.peer-2.internal-address.grpc=$PEER_2:1731"
+#        export OPTS_PEER_3="--server.peers.peer-3.address=$PEER_3:1729 --server.peers.peer-3.internal-address.zeromq=$PEER_3:1730 --server.peers.peer-3.internal-address.grpc=$PEER_3:1731"
+#        bazel run @vaticle_dependencies//tool/util:create-systemd-service -- typedb-cluster "$BIN $OPTS_ADDR $OPTS_PEER_1 $OPTS_PEER_2 $OPTS_PEER_3"
+#
+#        sudo systemctl daemon-reload
+#        sudo systemctl start typedb-cluster
+#
+#        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI="${HOSTNAME}:1729"
+#      monitor: |
+#        sleep 20s
+#        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
+#    test-performance-typedb-cluster-three-server-3:
+#      machine: 16-core-32-gb
+#      image: vaticle-ubuntu-21.04
+#      type: background
+#      dependencies: [test-performance-typedb-cluster-three-bootstrapper]
+#      timeout: "30m"
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        bazel run @vaticle_dependencies//tool/util:install-ssh-credential
+#
+#        echo -n "${HOSTNAME}" > /tmp/typedb-cluster-server-3.txt
+#        bazel run @vaticle_dependencies//tool/util:transfer-file -- /tmp/typedb-cluster-server-3.txt \
+#          grabl@$GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_BOOTSTRAPPER_URI:/tmp/typedb-cluster-server-3.txt
+#
+#        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-1.txt
+#        bazel run @vaticle_dependencies//tool/util:wait-for-file -- /tmp/typedb-cluster-server-2.txt
+#
+#        bazel run //test:typedb-cluster-extractor-linux -- dist/typedb-cluster-all-linux
+#        PEER_1=$(cat /tmp/typedb-cluster-server-1.txt)
+#        PEER_2=$(cat /tmp/typedb-cluster-server-2.txt)
+#        PEER_3=$(cat /tmp/typedb-cluster-server-3.txt)
+#        export BIN="\/home\/grabl\/$GRABL_REPO\/dist\/typedb-cluster-all-linux\/typedb cluster"
+#        export OPTS_ADDR="--server.address=$PEER_3:1729 --server.internal-address.zeromq=$PEER_3:1730 --server.internal-address.grpc=$PEER_3:1731"
+#        export OPTS_PEER_1="--server.peers.peer-1.address=$PEER_1:1729 --server.peers.peer-1.internal-address.zeromq=$PEER_1:1730 --server.peers.peer-1.internal-address.grpc=$PEER_1:1731"
+#        export OPTS_PEER_2="--server.peers.peer-2.address=$PEER_2:1729 --server.peers.peer-2.internal-address.zeromq=$PEER_2:1730 --server.peers.peer-2.internal-address.grpc=$PEER_2:1731"
+#        export OPTS_PEER_3="--server.peers.peer-3.address=$PEER_3:1729 --server.peers.peer-3.internal-address.zeromq=$PEER_3:1730 --server.peers.peer-3.internal-address.grpc=$PEER_3:1731"
+#        bazel run @vaticle_dependencies//tool/util:create-systemd-service -- typedb-cluster "$BIN $OPTS_ADDR $OPTS_PEER_1 $OPTS_PEER_2 $OPTS_PEER_3"
+#
+#        sudo systemctl daemon-reload
+#        sudo systemctl start typedb-cluster
+#
+#        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI="${HOSTNAME}:1729"
+#      monitor: |
+#        sleep 20s
+#        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
+#    test-performance-typedb-cluster-three-benchmark:
+#      machine: 16-core-32-gb
+#      image: vaticle-ubuntu-21.04
+#      dependencies: [test-performance-typedb-cluster-three-server-1, test-performance-typedb-cluster-three-server-2, test-performance-typedb-cluster-three-server-3]
+#      timeout: "30m"
+#      command: |
+#       bazel run //:benchmark -- \
+#         --database typedb-cluster \
+#         --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI \
+#         --config /home/grabl/$GRABL_REPO/config/simulation.yml

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -18,7 +18,7 @@
 build:
   correctness:
     build:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -27,14 +27,14 @@ build:
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
     build-dependency:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       command: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
     test-comparison-typedb-core-server:
       machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       type: background
       timeout: "30m"
       command: |
@@ -50,7 +50,7 @@ build:
         tail -f -n +1 /home/grabl/$GRABL_REPO/dist/typedb-all-linux/server/logs/typedb.log
     test-comparison-neo4j-server:
       machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       type: background
       timeout: "30m"
       command: |
@@ -72,7 +72,7 @@ build:
         journalctl -fu neo4j
     test-comparison:
       machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       timeout: "30m"
       dependencies: [test-comparison-typedb-core-server, test-comparison-neo4j-server]
       command: |
@@ -97,7 +97,7 @@ build:
   performance:
     test-performance-typedb-core-server:
       machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       type: background
       timeout: "30m"
       command: |
@@ -113,7 +113,7 @@ build:
         tail -f -n +1 ./dist/typedb-all-linux/server/logs/typedb.log
     test-performance-typedb-core-benchmark:
       machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       dependencies: [test-performance-typedb-core-server]
       timeout: "30m"
       command: |
@@ -129,7 +129,7 @@ build:
           --token $GRABL_TOKEN
     test-performance-neo4j-server:
       machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       type: background
       timeout: "30m"
       monitor: |
@@ -151,7 +151,7 @@ build:
         export GRABL_EXPORT_PERFORMANCE_NEO4J_URI="${HOSTNAME}:7687"
     test-performance-neo4j-benchmark:
       machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       dependencies: [ test-performance-neo4j-server ]
       timeout: "30m"
       command: |
@@ -180,7 +180,7 @@ build:
           --token $GRABL_TOKEN
     test-performance-typedb-cluster-one-server:
       machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       type: background
       timeout: "30m"
       command: |
@@ -200,7 +200,7 @@ build:
         tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
     test-performance-typedb-cluster-one-benchmark:
       machine: 16-core-32-gb
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       dependencies: [test-performance-typedb-cluster-one-server]
       timeout: "30m"
       command: |
@@ -215,7 +215,7 @@ build:
          --username $GRABL_OWNER \
          --token $GRABL_TOKEN
 #    test-performance-typedb-cluster-three-bootstrapper:
-#      image: vaticle-ubuntu-21.04
+#      image: vaticle-ubuntu-20.04
 #      type: background
 #      command: |
 #        bazel run @vaticle_dependencies//tool/util:install-ssh-credential
@@ -241,7 +241,7 @@ build:
 #        sleep 1800
 #    test-performance-typedb-cluster-three-server-1:
 #      machine: 16-core-32-gb
-#      image: vaticle-ubuntu-21.04
+#      image: vaticle-ubuntu-20.04
 #      type: background
 #      dependencies: [test-performance-typedb-cluster-three-bootstrapper]
 #      timeout: "30m"
@@ -279,7 +279,7 @@ build:
 #        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
 #    test-performance-typedb-cluster-three-server-2:
 #      machine: 16-core-32-gb
-#      image: vaticle-ubuntu-21.04
+#      image: vaticle-ubuntu-20.04
 #      type: background
 #      dependencies: [test-performance-typedb-cluster-three-bootstrapper]
 #      timeout: "30m"
@@ -317,7 +317,7 @@ build:
 #        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
 #    test-performance-typedb-cluster-three-server-3:
 #      machine: 16-core-32-gb
-#      image: vaticle-ubuntu-21.04
+#      image: vaticle-ubuntu-20.04
 #      type: background
 #      dependencies: [test-performance-typedb-cluster-three-bootstrapper]
 #      timeout: "30m"
@@ -355,7 +355,7 @@ build:
 #        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
 #    test-performance-typedb-cluster-three-benchmark:
 #      machine: 16-core-32-gb
-#      image: vaticle-ubuntu-21.04
+#      image: vaticle-ubuntu-20.04
 #      dependencies: [test-performance-typedb-cluster-three-server-1, test-performance-typedb-cluster-three-server-2, test-performance-typedb-cluster-three-server-3]
 #      timeout: "30m"
 #      command: |

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -120,7 +120,13 @@ build:
         bazel run //:benchmark -- \
           --database typedb \
           --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CORE_URI \
-          --config /home/grabl/$GRABL_REPO/config/simulation.yml
+          --config /home/grabl/$GRABL_REPO/config/simulation.yml \
+          --factory $GRABL_TRACING_URI \
+          --org $GRABL_OWNER \
+          --repo $GRABL_REPO \
+          --commit $GRABL_COMMIT \
+          --username $GRABL_OWNER \
+          --token $GRABL_TOKEN
     test-performance-neo4j-server:
       machine: 16-core-32-gb
       image: vaticle-ubuntu-21.04
@@ -165,37 +171,49 @@ build:
         bazel run //:benchmark -- \
           --database neo4j \
           --address bolt://$GRABL_EXPORT_PERFORMANCE_NEO4J_URI \
-          --config /home/grabl/$GRABL_REPO/config/simulation.yml
-#    test-performance-typedb-cluster-one-server:
-#      machine: 16-core-32-gb
-#      image: vaticle-ubuntu-21.04
-#      type: background
-#      timeout: "30m"
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#
-#        bazel run //test:typedb-cluster-extractor-linux -- dist/typedb-cluster-all-linux
-#        bazel run @vaticle_dependencies//tool/util:create-systemd-service -- typedb-cluster "\/home\/grabl\/$GRABL_REPO\/dist\/typedb-cluster-all-linux\/typedb cluster --server.address=${HOSTNAME}:1729"
-#
-#        sudo systemctl daemon-reload
-#        sudo systemctl start typedb-cluster
-#
-#        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI="${HOSTNAME}:1729"
-#      monitor: |
-#        sleep 20s
-#        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
-#    test-performance-typedb-cluster-one-benchmark:
-#      machine: 16-core-32-gb
-#      image: vaticle-ubuntu-21.04
-#      dependencies: [test-performance-typedb-cluster-one-server]
-#      timeout: "30m"
-#      command: |
-#       bazel run //:benchmark -- \
-#         --database typedb-cluster \
-#         --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI \
-#         --config /home/grabl/$GRABL_REPO/config/simulation.yml
+          --config /home/grabl/$GRABL_REPO/config/simulation.yml \
+          --factory $GRABL_TRACING_URI \
+          --org $GRABL_OWNER \
+          --repo $GRABL_REPO \
+          --commit $GRABL_COMMIT \
+          --username $GRABL_OWNER \
+          --token $GRABL_TOKEN
+    test-performance-typedb-cluster-one-server:
+      machine: 16-core-32-gb
+      image: vaticle-ubuntu-21.04
+      type: background
+      timeout: "30m"
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+
+        bazel run //test:typedb-cluster-extractor-linux -- dist/typedb-cluster-all-linux
+        bazel run @vaticle_dependencies//tool/util:create-systemd-service -- typedb-cluster "\/home\/grabl\/$GRABL_REPO\/dist\/typedb-cluster-all-linux\/typedb cluster --server.address=${HOSTNAME}:1729"
+
+        sudo systemctl daemon-reload
+        sudo systemctl start typedb-cluster
+
+        export GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI="${HOSTNAME}:1729"
+      monitor: |
+        sleep 20s
+        tail -f -n +1 ./dist/typedb-cluster-all-linux/server/logs/typedb.log
+    test-performance-typedb-cluster-one-benchmark:
+      machine: 16-core-32-gb
+      image: vaticle-ubuntu-21.04
+      dependencies: [test-performance-typedb-cluster-one-server]
+      timeout: "30m"
+      command: |
+       bazel run //:benchmark -- \
+         --database typedb-cluster \
+         --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI \
+         --config /home/grabl/$GRABL_REPO/config/simulation.yml \
+         --factory $GRABL_TRACING_URI \
+         --org $GRABL_OWNER \
+         --repo $GRABL_REPO \
+         --commit $GRABL_COMMIT \
+         --username $GRABL_OWNER \
+         --token $GRABL_TOKEN
 #    test-performance-typedb-cluster-three-bootstrapper:
 #      image: vaticle-ubuntu-21.04
 #      type: background
@@ -344,4 +362,10 @@ build:
 #       bazel run //:benchmark -- \
 #         --database typedb-cluster \
 #         --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI \
-#         --config /home/grabl/$GRABL_REPO/config/simulation.yml
+#         --config /home/grabl/$GRABL_REPO/config/simulation.yml \
+#         --factory $GRABL_TRACING_URI \
+#         --org $GRABL_OWNER \
+#         --repo $GRABL_REPO \
+#         --commit $GRABL_COMMIT \
+#         --username $GRABL_OWNER \
+#         --token $GRABL_TOKEN

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -121,12 +121,12 @@ build:
           --database typedb \
           --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CORE_URI \
           --config /home/grabl/$GRABL_REPO/config/simulation.yml \
-          --factory $GRABL_TRACING_URI \
-          --org $GRABL_OWNER \
-          --repo $GRABL_REPO \
-          --commit $GRABL_COMMIT \
-          --username $GRABL_OWNER \
-          --token $GRABL_TOKEN
+#          --factory $GRABL_TRACING_URI \
+#          --org $GRABL_OWNER \
+#          --repo $GRABL_REPO \
+#          --commit $GRABL_COMMIT \
+#          --username $GRABL_OWNER \
+#          --token $GRABL_TOKEN
     test-performance-neo4j-server:
       machine: 16-core-32-gb
       image: vaticle-ubuntu-20.04
@@ -172,12 +172,12 @@ build:
           --database neo4j \
           --address bolt://$GRABL_EXPORT_PERFORMANCE_NEO4J_URI \
           --config /home/grabl/$GRABL_REPO/config/simulation.yml \
-          --factory $GRABL_TRACING_URI \
-          --org $GRABL_OWNER \
-          --repo $GRABL_REPO \
-          --commit $GRABL_COMMIT \
-          --username $GRABL_OWNER \
-          --token $GRABL_TOKEN
+#          --factory $GRABL_TRACING_URI \
+#          --org $GRABL_OWNER \
+#          --repo $GRABL_REPO \
+#          --commit $GRABL_COMMIT \
+#          --username $GRABL_OWNER \
+#          --token $GRABL_TOKEN
     test-performance-typedb-cluster-one-server:
       machine: 16-core-32-gb
       image: vaticle-ubuntu-20.04
@@ -208,12 +208,12 @@ build:
          --database typedb-cluster \
          --address $GRABL_EXPORT_PERFORMANCE_TYPEDB_CLUSTER_SERVER_URI \
          --config /home/grabl/$GRABL_REPO/config/simulation.yml \
-         --factory $GRABL_TRACING_URI \
-         --org $GRABL_OWNER \
-         --repo $GRABL_REPO \
-         --commit $GRABL_COMMIT \
-         --username $GRABL_OWNER \
-         --token $GRABL_TOKEN
+#         --factory $GRABL_TRACING_URI \
+#         --org $GRABL_OWNER \
+#         --repo $GRABL_REPO \
+#         --commit $GRABL_COMMIT \
+#         --username $GRABL_OWNER \
+#         --token $GRABL_TOKEN
 #    test-performance-typedb-cluster-three-bootstrapper:
 #      image: vaticle-ubuntu-20.04
 #      type: background


### PR DESCRIPTION
## What is the goal of this PR?

We add back the Neo4J benchmark to allow comparisons between TypeDB and Neo4j. We also comment out the 3-node cluster tests, and keep only Neo4j, TypeDB, and TypeDB Cluster with 1 node as our baseline. Factory-tracing can also be enabled via the factory-tracing arguments to benchmark, once the tracing SSL issues are resolved.

## What are the changes implemented in this PR?

* Restore deleted CI jobs for Neo4j
* Add back factory-tracing API usage, but comment it out since tracing has SSL issues
* Remove 3-node cluster benchmarking