### PR TITLE
Fixed always using default number of agent runs

### DIFF
--- a/Agent.kt
+++ b/Agent.kt
@@ -51,7 +51,7 @@ abstract class Agent<PARTITION: Partition, SESSION, CONTEXT: Context<*, *>> prot
 
     fun run(session: SESSION, partition: PARTITION, random: RandomSource): List<Report> {
         return actionHandlers[action]?.let {
-            (0..runsPerIteration).flatMap { it(session, partition, random) }
+            (0 until runsPerIteration).flatMap { it(session, partition, random) }
         } ?: throw IllegalArgumentException("The action '$action' has no registered handler in '${javaClass.simpleName}'"
                 + if (action == DEFAULT_ACTION) " (help: '$action' is the default action)" else "")
     }

--- a/Simulation.kt
+++ b/Simulation.kt
@@ -49,6 +49,7 @@ abstract class Simulation<CLIENT: DBClient<*>, out CONTEXT: Context<*, *>>(
             agent.apply {
                 action = agentConfig.action
                 tracingEnabled = agentConfig.trace
+                runsPerIteration = agentConfig.runsPerIteration
             }.also { _registeredAgents += agentClass }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

Each agent was always run the default number of times as the value was not overriden by the value provided in the config file. An erroneous inclusive bound has also been changed to an exclusive bound.

## What are the changes implemented in this PR?

Trivial modifications to Agent and Simulation classes.
