### PR TITLE
Allowed simulations to specify multiple schema files

### DIFF
--- a/typedb/TypeDBSimulation.kt
+++ b/typedb/TypeDBSimulation.kt
@@ -56,8 +56,8 @@ abstract class TypeDBSimulation<out CONTEXT: Context<*, *>> protected constructo
     }
 
     private fun initSchema(nativeClient: com.vaticle.typedb.client.api.TypeDBClient) {
+        if (schemaFiles.isEmpty()) throw IllegalStateException("No schema files provided for simulation.")
         nativeClient.session(context.dbName, SCHEMA).use { session ->
-            if (schemaFiles.isEmpty()) throw IllegalStateException("No schema files provided for simulation.")
             LOGGER.info("TypeDB initialisation of $name simulation schema started ...")
             val start = Instant.now()
             session.transaction(WRITE).use { tx ->

--- a/typedb/TypeDBSimulation.kt
+++ b/typedb/TypeDBSimulation.kt
@@ -57,6 +57,7 @@ abstract class TypeDBSimulation<out CONTEXT: Context<*, *>> protected constructo
 
     private fun initSchema(nativeClient: com.vaticle.typedb.client.api.TypeDBClient) {
         nativeClient.session(context.dbName, SCHEMA).use { session ->
+            if (schemaFiles.isEmpty()) throw IllegalStateException("No schema files provided for simulation.")
             LOGGER.info("TypeDB initialisation of $name simulation schema started ...")
             val start = Instant.now()
             session.transaction(WRITE).use { tx ->


### PR DESCRIPTION
## What is the goal of this PR?

Allows the TypeQL used to define the schema for the TypeDB simulation to be split over multiple files.

## What are the changes implemented in this PR?

Minor changes to the TypeDBSimulation class to replace the schema file variable with a list of schema files and handle it accordingly. This is a breaking change for any simulations depending on this repo.
