### PR TITLE
Exclude readme from checkstyle test

### DIFF
--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -1,5 +1,6 @@
 @maven//:ch_qos_logback_logback_classic_1_2_7
 @maven//:ch_qos_logback_logback_core_1_2_7
+@maven//:com_eclipsesource_minimal_json_minimal_json_0_9_5
 @maven//:com_google_android_annotations_4_1_1_4
 @maven//:com_google_api_grpc_proto_google_common_protos_2_0_1
 @maven//:com_google_code_findbugs_annotations_3_0_1

--- a/read-write/BUILD
+++ b/read-write/BUILD
@@ -52,5 +52,6 @@ java_binary(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
+    exclude = ["README.md"],
     license_type = "agpl-header",
 )


### PR DESCRIPTION
## What is the goal of this PR?
Fixes check style test by excluding readme from license checks; Updates the maven dependency snapshot.

## What are the changes implemented in this PR?
* Excludes `read-write/README.md` from the check style test to fix checkstyle failing on CI
* Has the updated `artifacts.snapshot` from running update.sh
