### PR TITLE
Reduce batch size to the smaller recommended size

### DIFF
--- a/read-write/config/large-data-benchmark.yml
+++ b/read-write/config/large-data-benchmark.yml
@@ -19,12 +19,12 @@ agents:
 
   - name: "PersonAgent"
     action: "createPerson"
-    runsPerIteration: 100
+    runsPerIteration: 2000
     trace: false
 
   - name: "PersonAgent"
     action: "createFriendship"
-    runsPerIteration: 100
+    runsPerIteration: 10000
     trace: false
 
   - name: "PersonAgent"
@@ -56,6 +56,6 @@ run:
   parallelism: 16
 
 model:
-  personsCreatedPerRun: 100
-  friendshipsCreatedPerRun: 500
+  personsCreatedPerRun: 5
+  friendshipsCreatedPerRun: 5
   postCodes: 97


### PR DESCRIPTION
## What is the goal of this PR?
Change batch-sizes to be limited to ~64 keys, as advised.

## What are the changes implemented in this PR?
- Revise batch sizes to 5 persons per batch x 2000 iters ( == 100 persons per batch * 100 iters)
- 5 friendships per batch x 10000 iters ( == 500 persons per batch * 100 iters)