### PR TITLE
Create delete benchmark

### DIFF
--- a/read-write/PersonAgent.kt
+++ b/read-write/PersonAgent.kt
@@ -28,7 +28,7 @@ import java.time.LocalDateTime
 import java.util.*
 
 public class PersonAgent(client: TypeDBClient, context: Context) :
-    Agent<Context.DBPartition, TypeDBSession, Context>(client, context) {
+        Agent<Context.DBPartition, TypeDBSession, Context>(client, context) {
 
     override val agentClass = PersonAgent::class.java
     override val partitions = context.partitions
@@ -54,16 +54,16 @@ public class PersonAgent(client: TypeDBClient, context: Context) :
     }
 
     fun createPerson(
-        session: TypeDBSession,
-        dbPartition: Context.DBPartition,
-        randomSource: RandomSource
+            session: TypeDBSession,
+            dbPartition: Context.DBPartition,
+            randomSource: RandomSource
     ): List<Agent.Report> {
-        val inserts = List(context.model.personPerBatch) {
+        val inserts = List(context.model.personCreatePerAction) {
             val id: Int = dbPartition.idCtr.addAndGet(1)
             TypeQL.cVar("p_" + it).isa("person")
-                .has("name", nameFrom(dbPartition.partitionId, id))
-                .has("post-code", postCodeFrom(dbPartition.partitionId, id))
-                .has("address", addressFrom(dbPartition.partitionId, id))
+                    .has("name", nameFrom(dbPartition.partitionId, id))
+                    .has("post-code", postCodeFrom(dbPartition.partitionId, id))
+                    .has("address", addressFrom(dbPartition.partitionId, id))
         }
         session.transaction(TypeDBTransaction.Type.WRITE, options).use { tx ->
             tx.query().insert(TypeQL.insert(inserts))
@@ -73,22 +73,52 @@ public class PersonAgent(client: TypeDBClient, context: Context) :
     }
 
     fun createFriendship(
-        session: TypeDBSession,
-        dbPartition: Context.DBPartition,
-        randomSource: RandomSource
+            session: TypeDBSession,
+            dbPartition: Context.DBPartition,
+            randomSource: RandomSource
     ): List<Agent.Report> {
         session.transaction(TypeDBTransaction.Type.WRITE, options).use { tx ->
-            for (i in 1..context.model.friendshipPerBatch) {
+            for (i in 1..context.model.friendshipCreatePerAction) {
                 val first: Int = 1 + randomSource.nextInt(dbPartition.idCtr.get())
                 val second: Int = 1 + randomSource.nextInt(dbPartition.idCtr.get())
                 tx.query().insert(
-                    TypeQL.match(
-                        TypeQL.cVar("p1").isa("person").has("name", nameFrom(dbPartition.partitionId, first)),
-                        TypeQL.cVar("p2").isa("person").has("name", nameFrom(dbPartition.partitionId, second)),
-                    ).insert(
-                        TypeQL.rel("person", TypeQL.cVar("p1")).rel("person", TypeQL.cVar("p1")).isa("friendship")
-                            .has("meeting-time", dateFrom(first, second))
-                    )
+                        TypeQL.match(
+                                TypeQL.cVar("p1").isa("person").has("name", nameFrom(dbPartition.partitionId, first)),
+                                TypeQL.cVar("p2").isa("person").has("name", nameFrom(dbPartition.partitionId, second)),
+                        ).insert(
+                                TypeQL.rel("person", TypeQL.cVar("p1")).rel("person", TypeQL.cVar("p1")).isa("friendship")
+                                        .has("meeting-time", dateFrom(first, second))
+                        )
+                )
+            }
+            tx.commit()
+        }
+        return listOf()
+    }
+
+    fun deletePersons(
+            session: TypeDBSession,
+            dbPartition: Context.DBPartition,
+            randomSource: RandomSource
+    ): List<Agent.Report> {
+        session.transaction(TypeDBTransaction.Type.WRITE, options).use { tx ->
+            for (i in 1..context.model.tryPersonDeletePerAction) {
+                val id: Int = randomSource.nextInt(dbPartition.idCtr.get())
+                tx.query().delete(
+                        TypeQL.match(
+                                TypeQL.cVar("p1").isa("person")
+                                        .has("name", TypeQL.cVar("name"))
+                                        .has("address", TypeQL.cVar("addr"))
+                                        .has("post-code", postCodeFrom(dbPartition.partitionId, id)),
+                                TypeQL.cVar("f").rel(TypeQL.cVar("p1")).isa("friendship")
+                                        .has("meeting-time", TypeQL.cVar("mt"))
+                        ).delete(
+                                TypeQL.cVar("p1").isa("person"),
+                                TypeQL.cVar("name").isa("name"),
+                                TypeQL.cVar("addr").isa("address"),
+                                TypeQL.cVar("f").isa("friendship"),
+                                TypeQL.cVar("mt").isa("meeting-time")
+                        )
                 )
             }
             tx.commit()
@@ -97,85 +127,86 @@ public class PersonAgent(client: TypeDBClient, context: Context) :
     }
 
     fun readFriendsOf(
-        session: TypeDBSession,
-        dbPartition: Context.DBPartition,
-        randomSource: RandomSource
+            session: TypeDBSession,
+            dbPartition: Context.DBPartition,
+            randomSource: RandomSource
     ): List<Agent.Report> {
         session.transaction(TypeDBTransaction.Type.WRITE, options).use { tx ->
             val id: Int = 1 + randomSource.nextInt(dbPartition.idCtr.get())
             tx.query().match(
-                TypeQL.match(
-                    TypeQL.cVar("p1").isa("person").has("name", nameFrom(dbPartition.partitionId, id)),
-                    TypeQL.rel("person", TypeQL.cVar("p1")).rel("person", TypeQL.cVar("p2")).isa("friendship"),
-                    TypeQL.cVar("p2").isa("person").has("name", TypeQL.cVar("n2")),
-                ).count()
+                    TypeQL.match(
+                            TypeQL.cVar("p1").isa("person").has("name", nameFrom(dbPartition.partitionId, id)),
+                            TypeQL.rel("person", TypeQL.cVar("p1")).rel("person", TypeQL.cVar("p2")).isa("friendship"),
+                            TypeQL.cVar("p2").isa("person").has("name", TypeQL.cVar("n2")),
+                    ).count()
             ).get()
         }
         return listOf()
     }
 
     fun readFriendsOfFriends(
-        session: TypeDBSession,
-        dbPartition: Context.DBPartition,
-        randomSource: RandomSource
+            session: TypeDBSession,
+            dbPartition: Context.DBPartition,
+            randomSource: RandomSource
     ): List<Agent.Report> {
         session.transaction(TypeDBTransaction.Type.WRITE, options).use { tx ->
             val id: Int = 1 + randomSource.nextInt(dbPartition.idCtr.get())
             tx.query().match(
-                TypeQL.match(
-                    TypeQL.cVar("p1").isa("person").has("name", nameFrom(dbPartition.partitionId, id)),
-                    TypeQL.rel("person", TypeQL.cVar("p1")).rel("person", TypeQL.cVar("p2")).isa("friendship"),
-                    TypeQL.rel("person", TypeQL.cVar("p2")).rel("person", TypeQL.cVar("p3")).isa("friendship"),
-                    TypeQL.cVar("p3").isa("person").has("name", TypeQL.cVar("n3")),
-                ).count()
+                    TypeQL.match(
+                            TypeQL.cVar("p1").isa("person").has("name", nameFrom(dbPartition.partitionId, id)),
+                            TypeQL.rel("person", TypeQL.cVar("p1")).rel("person", TypeQL.cVar("p2")).isa("friendship"),
+                            TypeQL.rel("person", TypeQL.cVar("p2")).rel("person", TypeQL.cVar("p3")).isa("friendship"),
+                            TypeQL.cVar("p3").isa("person").has("name", TypeQL.cVar("n3")),
+                    ).count()
             ).get()
         }
         return listOf()
     }
 
     fun readPersonsByPostCode(
-        session: TypeDBSession,
-        dbPartition: Context.DBPartition,
-        randomSource: RandomSource
+            session: TypeDBSession,
+            dbPartition: Context.DBPartition,
+            randomSource: RandomSource
     ): List<Agent.Report> {
         session.transaction(TypeDBTransaction.Type.WRITE, options).use { tx ->
             val postCode: Long =
-                postCodeFrom(dbPartition.partitionId, randomSource.nextInt(context.model.nPostCodes))
+                    postCodeFrom(dbPartition.partitionId, randomSource.nextInt(context.model.nPostCodes))
             tx.query().match(
-                TypeQL.match(
-                    TypeQL.cVar("p1").isa("person")
-                        .has("post-code", postCode)
-                        .has("name", TypeQL.cVar("name")),
-                ).count()
+                    TypeQL.match(
+                            TypeQL.cVar("p1").isa("person")
+                                    .has("post-code", postCode)
+                                    .has("name", TypeQL.cVar("name")),
+                    ).count()
             ).get()
         }
         return listOf()
     }
 
     fun readAddressFromName(
-        session: TypeDBSession,
-        dbPartition: Context.DBPartition,
-        randomSource: RandomSource
+            session: TypeDBSession,
+            dbPartition: Context.DBPartition,
+            randomSource: RandomSource
     ): List<Agent.Report> {
         session.transaction(TypeDBTransaction.Type.WRITE, options).use { tx ->
             val id: Int = 1 + randomSource.nextInt(dbPartition.idCtr.get())
             tx.query().match(
-                TypeQL.match(
-                    TypeQL.cVar("p1").isa("person")
-                        .has("name", nameFrom(dbPartition.partitionId, id))
-                        .has("address", TypeQL.cVar("addr")),
-                )
+                    TypeQL.match(
+                            TypeQL.cVar("p1").isa("person")
+                                    .has("name", nameFrom(dbPartition.partitionId, id))
+                                    .has("address", TypeQL.cVar("addr")),
+                    )
             ).count()
         }
         return listOf()
     }
 
     override val actionHandlers = mapOf(
-        "createPerson" to ::createPerson,
-        "createFriendship" to ::createFriendship,
-        "readAddressFromName" to ::readAddressFromName,
-        "readFriendsOf" to ::readFriendsOf,
-        "readFriendsOfFriends" to ::readFriendsOfFriends,
-        "readPersonsByPostCode" to ::readPersonsByPostCode,
+            "createPerson" to ::createPerson,
+            "createFriendship" to ::createFriendship,
+            "readAddressFromName" to ::readAddressFromName,
+            "readFriendsOf" to ::readFriendsOf,
+            "readFriendsOfFriends" to ::readFriendsOfFriends,
+            "readPersonsByPostCode" to ::readPersonsByPostCode,
+            "deletePersons" to ::deletePersons
     )
 }

--- a/read-write/PersonAgent.kt
+++ b/read-write/PersonAgent.kt
@@ -108,10 +108,10 @@ public class PersonAgent(client: TypeDBClient, context: Context) :
                         TypeQL.match(
                                 TypeQL.cVar("p1").isa("person")
                                         .has("name", TypeQL.cVar("name"))
-                                        .has("address", TypeQL.cVar("addr"))
-                                        .has("post-code", postCodeFrom(dbPartition.partitionId, id)),
+                                        .has("address", TypeQL.cVar("addr")),
                                 TypeQL.cVar("f").rel(TypeQL.cVar("p1")).isa("friendship")
-                                        .has("meeting-time", TypeQL.cVar("mt"))
+                                        .has("meeting-time", TypeQL.cVar("mt")),
+                                TypeQL.cVar("name").eq(nameFrom(dbPartition.partitionId, id))
                         ).delete(
                                 TypeQL.cVar("p1").isa("person"),
                                 TypeQL.cVar("name").isa("name"),
@@ -121,7 +121,11 @@ public class PersonAgent(client: TypeDBClient, context: Context) :
                         )
                 )
             }
-            tx.commit()
+            try {
+                tx.commit()
+            } catch (_: Exception) {
+
+            }
         }
         return listOf()
     }

--- a/read-write/common/ModelParams.kt
+++ b/read-write/common/ModelParams.kt
@@ -21,18 +21,24 @@ import com.vaticle.typedb.benchmark.readwrite.common.Util.int
 import com.vaticle.typedb.benchmark.readwrite.common.Util.map
 import com.vaticle.typedb.common.yaml.YAML
 
-class ModelParams private constructor(val personPerBatch: Int, val friendshipPerBatch: Int, val nPostCodes: Int) {
+class ModelParams private constructor(val personCreatePerAction: Int, val friendshipCreatePerAction: Int, val tryPersonDeletePerAction: Int, val nPostCodes: Int) {
 
     companion object {
-        private const val PERSONS_PER_RUN = "personsCreatedPerAction"
-        private const val FRIENDSHIPS_PER_RUN = "friendshipsCreatedPerAction"
+        private const val PERSON_CREATE_PER_ACTION = "personsCreatedPerAction"
+        private const val FRIENDSHIP_CREATE_PER_ACTION = "friendshipsCreatedPerAction"
+        private const val TRY_PERSON_DELETE_PER_ACTION = "tryPersonsDeletedPerAction"
         private const val POST_CODES = "postCodes"
 
         fun of(yaml: YAML.Map): ModelParams {
-            val nPersonPerBatch = int(map(yaml["model"])[PERSONS_PER_RUN])
-            val friendshipPerBatch = int(map(yaml["model"])[FRIENDSHIPS_PER_RUN])
+            val personCreatePerAction = int(map(yaml["model"])[PERSON_CREATE_PER_ACTION])
+            val friendshipCreatePerAction = int(map(yaml["model"])[FRIENDSHIP_CREATE_PER_ACTION])
+            val tryPersonDeletePerAction = intGetOrDefault(yaml["model"].asMap(), TRY_PERSON_DELETE_PER_ACTION, 0)
             val postCodes = int(map(yaml["model"])[POST_CODES])
-            return ModelParams(nPersonPerBatch, friendshipPerBatch, postCodes)
+            return ModelParams(personCreatePerAction, friendshipCreatePerAction, tryPersonDeletePerAction, postCodes)
+        }
+
+        fun intGetOrDefault(yaml: YAML.Map, key: String, default: Int): Int {
+            return if (yaml[key] == null) default else int(yaml[key])
         }
     }
 }

--- a/read-write/config/BUILD
+++ b/read-write/config/BUILD
@@ -30,8 +30,8 @@ filegroup(
     name = "benchmark-config",
     srcs = [
         "tiny-read-write-benchmark.yml",
+        "medium-delete-benchmark.yml",
         "medium-linear-read-write-benchmark.yml",
-        "large-delete-benchmark.yml",
         "large-write-benchmark.yml",
         "large-read-write-benchmark.yml",
     ],

--- a/read-write/config/BUILD
+++ b/read-write/config/BUILD
@@ -31,6 +31,7 @@ filegroup(
     srcs = [
         "tiny-read-write-benchmark.yml",
         "medium-linear-read-write-benchmark.yml",
+        "large-delete-benchmark.yml",
         "large-write-benchmark.yml",
         "large-read-write-benchmark.yml",
     ],

--- a/read-write/config/large-delete-benchmark.yml
+++ b/read-write/config/large-delete-benchmark.yml
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+agents:
+
+  - name: "PersonAgent"
+    action: "createPerson"
+    actionsPerIteration: 100
+    trace: false
+
+  - name: "PersonAgent"
+    action: "createFriendship"
+    actionsPerIteration: 100
+    trace: false
+
+  - name: "PersonAgent"
+    action: "deletePersons"
+    actionsPerIteration: 100
+    trace: false
+
+traceSampling:
+  # Options: `"every"` for every K traces; `"log"` for logarithm with base N
+  function: "every"
+  arg: 10
+
+run:
+  randomSeed: 1
+  iterations: 2500
+  partitions: 16
+  databaseName: "benchmark-large-delete"
+  recreateDatabase: true
+  parallelism: 16
+
+model:
+  personsCreatedPerAction: 100
+  friendshipsCreatedPerAction: 200
+  tryPersonsDeletedPerAction: 50
+  postCodes: 97

--- a/read-write/config/medium-delete-benchmark.yml
+++ b/read-write/config/medium-delete-benchmark.yml
@@ -39,7 +39,7 @@ traceSampling:
 
 run:
   randomSeed: 1
-  iterations: 2500
+  iterations: 100
   partitions: 16
   databaseName: "benchmark-large-delete"
   recreateDatabase: true


### PR DESCRIPTION
## What is the goal of this PR?

We introduce a delete-heavy benchmark to allow investigating and optimising TypeDB's delete path.

Run using:
```
bazel run //read-write:benchmark-runner -- --database=typedb --address=127.0.0.1:1729 --config=read-write/config/medium-delete-benchmark.yml
```

Note:  In TypeDB 2.21.1,aAfter 3 iterations, profiling shows 70% of time is spent on `seek()` on the storage layer, indicating a clear bottleneck or issue to be resolved.

## What are the changes implemented in this PR?

* Rename `run` to `action` throughout
* Introduce `deletePerson` action, which randomly samples people ID's from the range of inserted people and deletes them if they exist (they may already be deleted so this is a no-op)